### PR TITLE
Increase dbcache by 10% due to 0.19 improvements

### DIFF
--- a/rootfs/standard/usr/share/mynode/bitcoin.conf
+++ b/rootfs/standard/usr/share/mynode/bitcoin.conf
@@ -26,7 +26,7 @@ zmqpubrawblock=tcp://127.0.0.1:28332
 zmqpubrawtx=tcp://127.0.0.1:28333
 
 # myNode Optimizations
-dbcache=700
+dbcache=770
 maxorphantx=10
 maxmempool=200
 maxconnections=40


### PR DESCRIPTION
From https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.19.0.1.md:
>Users setting custom dbcache values can increase their setting slightly without using any more real memory. Recent changes reduced the memory use by about 9% and made chainstate accounting more accurate (it was underestimating the use of memory before). For example, if you set a value of "450" before, you may now set a value of "500" to use about the same real amount of memory. (#16957)