### PR TITLE
Minor tweaks to improve outputs from Bash scripts

### DIFF
--- a/make_rootfs.sh
+++ b/make_rootfs.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 for i in 'rock64' 'rockpro64' 'raspi3' 'raspi4' 'debian'; do
+	echo Creating root file system for $i
 	mkdir -p out/rootfs_$i/
 	rsync -r -u rootfs/standard/* out/rootfs_$i/
 	rsync -r -u rootfs/$i/* out/rootfs_$i/
 	rsync -r -u CHANGELOG out/rootfs_$i/usr/share/mynode/changelog
-    cp -f setup/setup_device.sh out/setup_device.sh
+	cp -f setup/setup_device.sh out/setup_device.sh
 
 	rm -f out/mynode_rootfs_$i.tar.gz
-	tar -zcvf out/mynode_rootfs_$i.tar.gz ./out/rootfs_$i/*
+	tar -zcf out/mynode_rootfs_$i.tar.gz out/rootfs_$i/*
 done
+echo Done!

--- a/rootfs/standard/usr/bin/mynode-local-upgrade
+++ b/rootfs/standard/usr/bin/mynode-local-upgrade
@@ -25,7 +25,9 @@ wget http://${ip_address}:8000/mynode_rootfs_${DEVICE_TYPE}.tar.gz -O /tmp/mynod
 # Extract on top of mynode fs
 rm -rf /tmp/rootfs/
 mkdir -p /tmp/rootfs/
-tar -xvf /tmp/mynode_rootfs_${DEVICE_TYPE}.tar.gz -C /tmp/rootfs/
+echo -n Extracting rootfs TAR for ${DEVICE_TYPE} ...
+tar -xf /tmp/mynode_rootfs_${DEVICE_TYPE}.tar.gz -C /tmp/rootfs/
+echo Done!
 
 # Install files
 if [ $IS_X86 = 1 ]; then

--- a/rootfs/standard/usr/share/mynode/mynode_config.sh
+++ b/rootfs/standard/usr/share/mynode/mynode_config.sh
@@ -9,7 +9,7 @@ IS_RASPI3=0
 IS_RASPI4=0
 IS_X86=0
 DEVICE_TYPE="unknown"
-MODEL=$(cat /proc/device-tree/model) || MODEL="unknown"
+MODEL=$(tr -d '\0' < /proc/device-tree/model) || MODEL="unknown"
 uname -a | grep amd64 && IS_X86=1 || true
 if [[ $MODEL == *"Rock64"* ]]; then 
     IS_ARMBIAN=1


### PR DESCRIPTION
- removed ugly TAR output while using `make rootfs`
- removed ugly TAR extraction while using `local-upgrade` script
- suppressed warning from null byte in `/proc/device-tree/model`