### PR TITLE
RTL 0.6.7 and Mempool.Space on CHANGELOG (reminder inside)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 - Update RTL to v0.6.5
 - Readd auto Tor reinstall
 - Clean rootfs before release
-- Mempool.Space docker improvements
+- Fix rendering glitches and improved performance on Mempool.Space
 
 === v0.1.91 ===
 - Add PCIe NVME Support for RockPro64

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - Update RTL to v0.6.5
 - Readd auto Tor reinstall
 - Clean rootfs before release
+- Mempool.Space docker improvements
 
 === v0.1.91 ===
 - Add PCIe NVME Support for RockPro64

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 === v0.1.92 ===
-- Update RTL to v0.6.5
+- Update RTL to v0.6.7
 - Readd auto Tor reinstall
 - Clean rootfs before release
 - Fix rendering glitches and improved performance on Mempool.Space


### PR DESCRIPTION
This is a reminder to update /opt/mynode/mempoolspace with latest pull from the git source. ;)