### PR TITLE
Fix Reparing drive - fsck Check and report.

### DIFF
--- a/rootfs/standard/usr/bin/mynode_startup.sh
+++ b/rootfs/standard/usr/bin/mynode_startup.sh
@@ -69,6 +69,7 @@ for d in /dev/sd*1; do
     if [ -n "$RC" ]; then
         touch /tmp/fsck_error
     fi
+    cat /tmp/tsck_results
 done
 rm -f /tmp/repairing_drive
 set -e


### PR DESCRIPTION
Fixes "Line 69 Unary operator expected" in Startup Log.
Changed check for stderrout and report results of fsck in startup log.