### PR TITLE
Updated "git clone" cmd to use latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Add another argument to the local upgrade script:
 Once you are running myNode, you can easily update the software yourself!
 
 1. Start by running myNode on your device via the instructions above in "Running myNode"
-2. Clone this git repo on your PC or laptop
-    * Run 'git clone https://github.com/mynodebtc/mynode.git'
+2. Clone the latest release from the git repo on your PC or laptop
+    * Run 'git clone https://github.com/mynodebtc/mynode.git --branch latest_release'
     * Run 'cd mynode'
 3. Run 'make rootfs'
 4. Run 'make start_file_server'


### PR DESCRIPTION
The local upgrade guide now contains the full git command for specifically cloning the latest tagged release, instead of the latest master branch state.

Releavant discussion in #228