### PR TITLE
Bitcoin status page: Check address list length before accessing first element

### DIFF
--- a/rootfs/standard/var/www/mynode/bitcoind.py
+++ b/rootfs/standard/var/www/mynode/bitcoind.py
@@ -172,7 +172,7 @@ def bitcoind_status_page():
         local_address = "..."
         if networkdata != None:
             local_address = "not none"
-            if "localaddresses" in networkdata:
+            if ("localaddresses" in networkdata) and (len(networkdata["localaddresses"]) > 0):
                 local_address = "{}:{}".format(networkdata["localaddresses"][0]["address"], networkdata["localaddresses"][0]["port"])
 
         # Balance


### PR DESCRIPTION
Small fix, checks whether "localaddresses" list in "getnetworkinfo" isn't empty before directly accessing first element.

(Without this, if the list is empty, the whole status page crashes on "list index out of range" and no status information is displayed.)