### PR TITLE
Upgrade to lndmanage v0.11.0

### DIFF
--- a/rootfs/standard/usr/bin/mynode_post_upgrade.sh
+++ b/rootfs/standard/usr/bin/mynode_post_upgrade.sh
@@ -124,8 +124,9 @@ fi
 
 
 # Install any pip3 software
+pip3 install --upgrade pip setuptools wheel
 pip3 install gnureadline --no-cache-dir
-pip3 install lndmanage==0.10.0 --no-cache-dir   # Install LND Manage (keep up to date with LND)
+pip3 install lndmanage==0.11.0 --no-cache-dir   # Install lndmanage (keep up to date with LND)
 pip3 install docker-compose --no-cache-dir
 pip3 install pipenv --no-cache-dir
 pip3 install bcrypt --no-cache-dir

--- a/setup/setup_device.sh
+++ b/setup/setup_device.sh
@@ -199,10 +199,10 @@ fi
 
 
 # Install Python3 specific tools (run multiple times to make sure success)
-pip3 install wheel setuptools
+pip3 install --upgrade pip wheel setuptools
 pip3 install bitstring lnd-grpc pycoin aiohttp connectrum python-bitcoinlib
 pip3 install gnureadline
-pip3 install lndmanage==0.10.0   # Install LND Manage (keep up to date with LND)
+pip3 install lndmanage==0.11.0   # Install LND Manage (keep up to date with LND)
 pip3 install docker-compose
 pip3 install pipenv
 pip3 install pysocks


### PR DESCRIPTION
## Description
Updates lndmanage to the latest [release](https://github.com/bitromortac/lndmanage/releases/tag/v0.11.0), which is compatible with LND v0.11.0. The update includes a bunch of [dependency updates](https://github.com/bitromortac/lndmanage/commit/9c29f17547fb2bdd248e79c570317f2ffc1f713a). I tested installation on a raspberry pi to check the ARM precompiled python wheels, however not on the mynode. I also checked that the other pypi packages in the list can be installed in parallel and that there's no version issue. I also added a line where pip, setuptools and wheel are upgraded, which sometimes can avoid installation failures of other packages.

## Checklist

* [ ] tested successfully on local MyNode, if yes, list the device(s) below

## List of test device(s)
Raspberry Pi 2, VMs: Debian, Fedora, Ubuntu
