### PR TITLE
Run fsck on /mnt/hdd for several possible disk types

### DIFF
--- a/rootfs/standard/usr/bin/mynode_startup.sh
+++ b/rootfs/standard/usr/bin/mynode_startup.sh
@@ -2,6 +2,7 @@
 
 set -e
 set -x 
+shopt -s nullglob
 
 source /usr/share/mynode/mynode_config.sh
 source /usr/share/mynode/mynode_app_versions.sh
@@ -79,7 +80,7 @@ umount /mnt/hdd || true
 set +e
 if [ $IS_X86 = 0 ]; then
     touch /tmp/repairing_drive
-    for d in /dev/sd*1; do
+    for d in /dev/sd*1 /dev/hd*1 /dev/vd*1 /dev/nvme*p1; do
         echo "Repairing drive $d ...";
         fsck -y $d > /tmp/fsck_results 2>&1
         RC=$?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## fsck could not run on /mnt/hdd on a RockPro64 
I got an error popup saying that fsck could not run successfully. I found out that mynode_startup.sh only looks for /dev/sd*1, but my RockPro64 has a M.2 SSD module which is addressed as /dev/nvme0.
So i took the wildcards from findBlockDevices in mount_drive.tcl and extended the for-loop. Also, shell options have to be set otherwise non-existing wildcards are used as valid loop variables.
<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

* [X ] tested successfully on local MyNode, if yes, list the device(s) below

## List of test device(s)

RockPro64 with M.2 SSD module, /mnt/hdd mounted under /dev/nvme0n1p1
