### PR TITLE
Change 'electrs...' to 'Electrum...' in the UI.

### DIFF
--- a/rootfs/standard/var/www/mynode/device_info.py
+++ b/rootfs/standard/var/www/mynode/device_info.py
@@ -563,7 +563,7 @@ def get_btcrpcexplorer_status_and_color_and_ready():
                     ready = True
             else:
                 color = "yellow"
-                status = "Waiting on electrs..."
+                status = "Waiting on Electrum..."
         else:
             color = "yellow"
             status = "Waiting on bitcoin..."

--- a/rootfs/standard/var/www/mynode/dojo.py
+++ b/rootfs/standard/var/www/mynode/dojo.py
@@ -34,7 +34,7 @@ def get_dojo_status():
                 dojo_status = "Running"
                 dojo_status_color = "green"
             else:
-                dojo_status = "Waiting on electrs..."
+                dojo_status = "Waiting on Electrum..."
                 dojo_status_color = "yellow"
         else:
             dojo_status = "Issue Starting"


### PR DESCRIPTION
I have a new MyNode and some tiles in the UI are displaying `Waiting on electrs...`.  Unsure of what this means, I inspect the HTML element and it says `Waiting on electrs...` too, so it's not a CSS truncation.

Turns out the string `electrs` is used in several places in source code, and it refers to Electrum Rust Server.  That's fine, but `electrs` is is not a userland-appropriate string.

**If merged** this PR changes `Waiting on electrs...` to `Waiting on Electrum...` in the UI in two locations.

**Update**: Checking the [docs](https://github.com/mynodebtc/mynode_docs) there appears to be no UI screenshots or documentation references to update as a result of this PR.