### PR TITLE
added darkmode button on home screen

### DIFF
--- a/rootfs/standard/var/www/mynode/settings.py
+++ b/rootfs/standard/var/www/mynode/settings.py
@@ -859,6 +859,17 @@ def toggle_darkmode_page():
         enable_darkmode()
     return redirect("/settings")
 
+@mynode_settings.route("/settings/toggle-darkmode-home")
+def toggle_darkmode_page_home():
+    check_logged_in()
+
+    if is_darkmode_enabled():
+        disable_darkmode()
+    else:
+        enable_darkmode()
+    return redirect("/")
+
+
 @mynode_settings.route("/settings/toggle-netdata")
 def toggle_netdata_page():
     check_logged_in()

--- a/rootfs/standard/var/www/mynode/templates/main.html
+++ b/rootfs/standard/var/www/mynode/templates/main.html
@@ -444,6 +444,11 @@
             {% if upgrade_available %}
             <a class="ui-button ui-widget ui-corner-all mynode_back" href="/settings"><span class="ui-icon ui-icon-notice"></span>upgrade&nbsp;</a>
             {% endif %}
+            {% if ui_settings['darkmode'] %}
+                <a class="ui-button ui-widget ui-corner-all mynode_back" href="/settings/toggle-darkmode-home" title="Disable Darkmode">&nbsp;<span class="ui-icon ui-icon-lightbulb"></span>&nbsp;</a>
+            {% else %}
+                <a class="ui-button ui-widget ui-corner-all mynode_back" href="/settings/toggle-darkmode-home" title="Enable Darkmode">&nbsp;<span class="ui-icon ui-icon-lightbulb"></span>&nbsp;</a>
+            {% endif %}
             <a class="ui-button ui-widget ui-corner-all mynode_back" id="https" title="Use HTTPS" style="display: none;" href="#">&nbsp;<span class="ui-icon ui-icon-locked"></span>&nbsp;</a>
             <a class="ui-button ui-widget ui-corner-all mynode_back" href="/logout" title="Logout"><span class="ui-icon ui-icon-close"></span>&nbsp;</a>
             <a class="ui-button ui-widget ui-corner-all mynode_back" id="power_button" title="Reboot or Shutdown"><span class="ui-icon ui-icon-power"></span>&nbsp;</a> 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
![image](https://user-images.githubusercontent.com/30268344/108773018-c2f7df00-752b-11eb-9084-7fc03c3c2101.png)

![image](https://user-images.githubusercontent.com/30268344/108773106-de62ea00-752b-11eb-8ff5-4448e576c791.png)

## Description
<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->
I have modified main.html to include a button in the top right corner to allow the user to toggle darkmode from the homescreen. This is done by modifying the settings.py to utilize the existing toggle functionality but to return the user to the home page instead of the settings page. Button is the same as existing top corner buttons and uses the light bulb graphic from the existing static images file.

## Checklist

* [x] tested successfully on local MyNode, if yes, list the device(s) below
* [ ] mentioned related open issue, if any

## List of test device(s)
Tested on local device which is a Raspi4
<!-- Raspi4, Rock64, VM -->
