### PR TITLE
Update Sphinx Relay to v2.0.4

### DIFF
--- a/rootfs/standard/usr/share/mynode/mynode_app_versions.sh
+++ b/rootfs/standard/usr/share/mynode/mynode_app_versions.sh
@@ -85,7 +85,7 @@ CKBUNKER_VERSION="v0.9"
 CKBUNKER_VERSION_FILE=/home/bitcoin/.mynode/ckbunker_version
 CKBUNKER_LATEST_VERSION_FILE=/home/bitcoin/.mynode/ckbunker_version_latest
 
-SPHINXRELAY_VERSION="v2.0.3"
+SPHINXRELAY_VERSION="v2.0.4"
 SPHINXRELAY_VERSION_FILE=/home/bitcoin/.mynode/sphinxrelay_version
 SPHINXRELAY_LATEST_VERSION_FILE=/home/bitcoin/.mynode/sphinxrelay_version_latest
 


### PR DESCRIPTION
Updates sphinx-relay to v2.0.4

## Description

v2.0.4 updates the connect UI, and includes checks for channel balancing and fee policy.

## Checklist

* [ ] tested successfully on local MyNode, if yes, list the device(s) below
* [ ] mentioned related open issue, if any

## List of test device(s)
