### PR TITLE
Do not explicitly set the index_batch_size in electrs, keep it on default

### DIFF
--- a/rootfs/standard/usr/share/mynode/electrs.toml
+++ b/rootfs/standard/usr/share/mynode/electrs.toml
@@ -8,7 +8,6 @@ db_dir = "/mnt/hdd/mynode/electrs"
 electrum_rpc_addr = "0.0.0.0:50001"
 monitoring_addr = "127.0.0.1:4224"
 bulk_index_threads = 3
-index_batch_size = 12
 txid_limit = 100
 tx_cache_size_mb = 10.0
 wait_duration_secs = 15


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The electrs gets stuck when running with `index_batch_size>10` on virtual machine which has only one CPU core available.

- https://github.com/mynodebtc/mynode/issues/569
- https://github.com/romanz/electrs/issues/564

This change removes the `index_batch_size` option from configuration. This value will be automatically set to its default, which is currently (electrs v0.9.{0,1}) `10`.



## Checklist

* [ ] tested successfully on local MyNode, if yes, list the device(s) below
* [x] mentioned related open issue, if any - 

## List of test device(s)
VM
