### PR TITLE
lncli: enable bash-completion

### DIFF
--- a/rootfs/standard/usr/bin/mynode_post_upgrade.sh
+++ b/rootfs/standard/usr/bin/mynode_post_upgrade.sh
@@ -316,6 +316,7 @@ if [ $IS_RASPI4_ARM64 = 1 ]; then
     LND_ARCH="lnd-linux-arm64"
 fi
 LND_UPGRADE_URL=https://github.com/lightningnetwork/lnd/releases/download/$LND_VERSION/$LND_ARCH-$LND_VERSION.tar.gz
+LNCLI_COMPLETION_URL=https://raw.githubusercontent.com/lightningnetwork/lnd/$LND_VERSION/contrib/lncli.bash-completion
 CURRENT=""
 if [ -f $LND_VERSION_FILE ]; then
     CURRENT=$(cat $LND_VERSION_FILE)
@@ -342,6 +343,10 @@ if [ "$CURRENT" != "$LND_VERSION" ]; then
     else
         echo "ERROR UPGRADING LND - GPG FAILED"
     fi
+
+    # Download bash-completion file for lncli
+    wget $LNCLI_COMPLETION_URL
+    sudo cp lncli.bash-completion /etc/bash_completion.d/lncli
 fi
 
 # Upgrade Loop

--- a/setup/setup_device.sh
+++ b/setup/setup_device.sh
@@ -371,6 +371,8 @@ if [ $IS_RASPI4_ARM64 = 1 ]; then
     LND_ARCH="lnd-linux-arm64"
 fi
 LND_UPGRADE_URL=https://github.com/lightningnetwork/lnd/releases/download/$LND_VERSION/$LND_ARCH-$LND_VERSION.tar.gz
+LNCLI_COMPLETION_URL=https://raw.githubusercontent.com/lightningnetwork/lnd/$LND_VERSION/contrib/lncli.bash-completion
+
 CURRENT=""
 if [ -f $LND_VERSION_FILE ]; then
     CURRENT=$(cat $LND_VERSION_FILE)
@@ -392,6 +394,10 @@ if [ "$CURRENT" != "$LND_VERSION" ]; then
     ln -s /bin/ip /usr/bin/ip || true
 
     echo $LND_VERSION > $LND_VERSION_FILE
+
+    # Download bash-completion file for lncli
+    wget $LNCLI_COMPLETION_URL
+    sudo cp lncli.bash-completion /etc/bash_completion.d/lncli
 fi
 cd ~
 


### PR DESCRIPTION
## Description

The LND repo includes a [bash-completion file](https://github.com/lightningnetwork/lnd/blob/master/contrib/lncli.bash-completion) for `lncli`, which simply needs to be saved in `/etc/bash_completion.d/` since the package is [already installed](https://github.com/mynodebtc/mynode/blob/v0.2.48/setup/setup_device.sh#L170). This change adds a `wget` and `sudo cp` to the LND section of the `mynode_post_upgrade.sh` script.

## Checklist

* [X] tested successfully on local MyNode, if yes, list the device(s) below
* [X] mentioned related open issue, if any
  * not applicable, no related issue

## List of test device(s)

Raspi4