### PR TITLE
bitcoin-cli: enable bash-completion

### DIFF
--- a/rootfs/standard/usr/bin/mynode_post_upgrade.sh
+++ b/rootfs/standard/usr/bin/mynode_post_upgrade.sh
@@ -273,6 +273,7 @@ fi
 BTC_UPGRADE_URL=https://bitcoincore.org/bin/bitcoin-core-$BTC_VERSION/bitcoin-$BTC_VERSION-$ARCH.tar.gz
 BTC_UPGRADE_SHA256SUM_URL=https://bitcoincore.org/bin/bitcoin-core-$BTC_VERSION/SHA256SUMS
 BTC_UPGRADE_SHA256SUM_ASC_URL=https://bitcoincore.org/bin/bitcoin-core-$BTC_VERSION/SHA256SUMS.asc
+BTC_CLI_COMPLETION_URL=https://raw.githubusercontent.com/bitcoin/bitcoin/v$BTC_VERSION/contrib/bitcoin-cli.bash-completion
 CURRENT=""
 if [ -f $BTC_VERSION_FILE ]; then
     CURRENT=$(cat $BTC_VERSION_FILE)
@@ -298,6 +299,10 @@ if [ "$CURRENT" != "$BTC_VERSION" ]; then
 
             # Mark current version
             echo $BTC_VERSION > $BTC_VERSION_FILE
+
+            # Install bash-completion for bitcoin-cli
+            wget $BTC_CLI_COMPLETION_URL -O bitcoin-cli.bash-completion
+            sudo cp bitcoin-cli.bash-completion /etc/bash_completion.d/bitcoin-cli
         else
             echo "ERROR UPGRADING BITCOIN - GPG FAILED"
         fi

--- a/setup/setup_device.sh
+++ b/setup/setup_device.sh
@@ -329,6 +329,7 @@ fi
 BTC_UPGRADE_URL=https://bitcoincore.org/bin/bitcoin-core-$BTC_VERSION/bitcoin-$BTC_VERSION-$ARCH.tar.gz
 BTC_UPGRADE_SHA256SUM_URL=https://bitcoincore.org/bin/bitcoin-core-$BTC_VERSION/SHA256SUMS
 BTC_UPGRADE_SHA256SUM_ASC_URL=https://bitcoincore.org/bin/bitcoin-core-$BTC_VERSION/SHA256SUMS.asc
+BTC_CLI_COMPLETION_URL=https://raw.githubusercontent.com/bitcoin/bitcoin/v$BTC_VERSION/contrib/bitcoin-cli.bash-completion
 CURRENT=""
 if [ -f $BTC_VERSION_FILE ]; then
     CURRENT=$(cat $BTC_VERSION_FILE)
@@ -359,6 +360,10 @@ if [ "$CURRENT" != "$BTC_VERSION" ]; then
     fi
     mkdir -p /home/admin/.bitcoin
     echo $BTC_VERSION > $BTC_VERSION_FILE
+
+    # Install bash-completion for bitcoin-cli
+    wget $BTC_CLI_COMPLETION_URL -O bitcoin-cli.bash-completion
+    sudo cp bitcoin-cli.bash-completion /etc/bash_completion.d/bitcoin-cli
 fi
 cd ~
 


### PR DESCRIPTION
## Description

The bitcoin github repo includes a [bash-completion file](https://github.com/bitcoin/bitcoin/blob/master/contrib/bitcoin-cli.bash-completion) for bitcoin-cli, which simply needs to be saved in /etc/bash_completion.d/ since the package is [already installed](https://github.com/mynodebtc/mynode/blob/v0.2.48/setup/setup_device.sh#L170). This change adds a `wget` and `sudo cp` to the Bitcoin sections of the `setup_device.sh` and `mynode_post_upgrade.sh` scripts.

## Checklist

* [X] tested successfully on local MyNode, if yes, list the device(s) below
* [X] mentioned related open issue, if any
  * not applicable, no related issue

## List of test device(s)

Raspi4
