### PR TITLE
Mitigate PwnKit vulnerability by removing setuid bit from pkexec

### DIFF
--- a/rootfs/standard/usr/bin/mynode_post_upgrade.sh
+++ b/rootfs/standard/usr/bin/mynode_post_upgrade.sh
@@ -47,6 +47,8 @@ if ! skip_base_upgrades ; then
     # Migrate from version file to version+install combo
     /usr/bin/mynode_migrate_version_files.sh
 
+    # PwnKit vulnerability mitigation
+    chmod 0755 /usr/bin/pkexec
 
     # Stop and disable any old services
     systemctl disable https || true


### PR DESCRIPTION
## Description

This removes the setuid bit from `/usr/bin/pkexec` to mitigate the recently published [PwnKit vulnerability](https://blog.qualys.com/vulnerabilities-threat-research/2022/01/25/pwnkit-local-privilege-escalation-vulnerability-discovered-in-polkits-pkexec-cve-2021-4034).

It seemed like the "base upgrades" section was the most appropriate place for it. I inserted it early to apply the mitigation prior to installing any new packages, in case any become compromised and attempt to exploit it. Feel free to move it elsewhere as you see fit.

## Checklist

* [X] tested successfully on local MyNode, if yes, list the device(s) below
* [ ] ~mentioned related open issue, if any~

## List of test device(s)

Raspi4, applied manually
