### PR TITLE
chore(deps): update jm config to adhere to v0.9.9 defaults

### DIFF
--- a/rootfs/standard/usr/share/mynode/joinmarket.cfg
+++ b/rootfs/standard/usr/share/mynode/joinmarket.cfg
@@ -1,15 +1,19 @@
+
 [DAEMON]
-#set to 1 to run the daemon service within this process;
-#set to 0 if the daemon is run separately (using script joinmarketd.py)
+# set to 1 to run the daemon service within this process;
+# set to 0 if the daemon is run separately (using script joinmarketd.py)
 no_daemon = 1
-#port on which daemon serves; note that communication still
-#occurs over this port even if no_daemon = 1
+
+# Port on which daemon serves; note that communication still
+# occurs over this port even if no_daemon = 1
 daemon_port = 27183
-#currently, running the daemon on a remote host is
-#*NOT* supported, so don't change this variable
+
+# Currently, running the daemon on a remote host is
+# *NOT* supported, so don't change this variable
 daemon_host = localhost
-#by default the client-daemon connection is plaintext, set to 'true' to use TLS;
-#for this, you need to have a valid (self-signed) certificate installed
+
+# by default the client-daemon connection is plaintext, set to 'true' to use TLS;
+# for this, you need to have a valid (self-signed) certificate installed
 use_ssl = false
 
 [BLOCKCHAIN]
@@ -28,49 +32,101 @@ rpc_user = mynode
 rpc_password = password
 rpc_wallet_file = joinmarket_wallet.dat
 
+[MESSAGING:onion]
+# onion based message channels must have the exact type 'onion'
+# (while the section name above can be MESSAGING:whatever), and there must
+# be only ONE such message channel configured (note the directory servers
+# can be multiple, below):
+type = onion
+
+socks5_host = localhost
+socks5_port = 9050
+
+# the tor control configuration.
+# for most people running the tor daemon
+# on Linux, no changes are required here:
+tor_control_host = localhost
+# or, to use a UNIX socket
+# tor_control_host = unix:/var/run/tor/control
+# note: port needs to be provided (but is ignored for UNIX socket)
+tor_control_port = 9051
+
+# the host/port actually serving the hidden service
+# (note the *virtual port*, that the client uses,
+# is hardcoded to as per below 'directory node configuration'.
+onion_serving_host = 127.0.0.1
+onion_serving_port = 8080
+
+# directory node configuration
+#
+# This is mandatory for directory nodes (who must also set their
+# own *.onion:port as the only directory in directory_nodes, below),
+# but NOT TO BE USED by non-directory nodes (which is you, unless
+# you know otherwise!), as it will greatly degrade your privacy.
+# (note the default is no value, don't replace it with "").
+hidden_service_dir =
+#
+# This is a comma separated list (comma can be omitted if only one item).
+# Each item has format host:port ; both are required, though port will
+# be 5222 if created in this code.
+# for MAINNET:
+directory_nodes = g3hv4uynnmynqqq2mchf3fcm3yd46kfzmcdogejuckgwknwyq5ya6iad.onion:5222,3kxw6lf5vf6y26emzwgibzhrzhmhqiw6ekrek3nqfjjmhwznb2moonad.onion:5222,bqlpq6ak24mwvuixixitift4yu42nxchlilrcqwk2ugn45tdclg42qid.onion:5222
+
+# for SIGNET (testing network):
+# directory_nodes = rr6f6qtleiiwic45bby4zwmiwjrj3jsbmcvutwpqxjziaydjydkk5iad.onion:5222,k74oyetjqgcamsyhlym2vgbjtvhcrbxr4iowd4nv4zk5sehw4v665jad.onion:5222,y2ruswmdbsfl4hhwwiqz4m3sx6si5fr6l3pf62d4pms2b53wmagq3eqd.onion:5222
+
+# This setting is ONLY for developer regtest setups,
+# running multiple bots at once. Don't alter it otherwise
+regtest_count = 0,0
+
+## IRC SERVER 1: Darkscience IRC (Tor, IP)
+################################################################################
 [MESSAGING:server1]
+# by default the legacy format without a `type` field is
+# understood to be IRC, but you can, optionally, add it:
+# type = irc
+channel = joinmarket-pit
+port = 6697
+usessl = true
+
+# For traditional IP:
 #host = irc.darkscience.net
-channel = joinmarket-pit
-port = 6697
-usessl = true
 #socks5 = false
-socks5_host = localhost
-socks5_port = 9050
 
-#for tor
-host = darksci3bfoka7tw.onion
+# For Tor (recommended as clearnet alternative):
+host = darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion
 socks5 = true
-
-[MESSAGING:server2]
-#host = irc.hackint.org
-channel = joinmarket-pit
-port = 6697
-usessl = true
-#socks5 = false
 socks5_host = localhost
 socks5_port = 9050
 
-#for tor
-host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
+## IRC SERVER 2: ILITA IRC (optional IRC alternate, Tor only)
+################################################################################
+[MESSAGING:server2]
+channel = joinmarket-pit
 port = 6667
 usessl = false
 socks5 = true
+socks5_host = localhost
 
-#Agora sometimes seems to be unreliable. Not active by default for that reason.
+host = ilitafrzzgxymv6umx2ux7kbz3imyeko6cnqkvy4nisjjj4qpqkrptid.onion
+socks5_port = 9050
+
+## IRC SERVER 3: (backup) hackint IRC (Tor, IP)
+################################################################################
 #[MESSAGING:server3]
-#host = agora.anarplex.net
-#channel = joinmarket-pit
-#port = 14716
-#usessl = true
-#socks5 = false
+# channel = joinmarket-pit
+# For traditional IP:
+## host = irc.hackint.org
+## port = 6697
+## usessl = true
+## socks5 = false
+# For Tor (default):
+#host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
+#port = 6667
+#usessl = false
+#socks5 = true
 #socks5_host = localhost
 #socks5_port = 9050
-#
-##for tor
-##host = cfyfz6afpgfeirst.onion
-##port = 6667
-##usessl = false
-##socks5 = true
 
 [LOGGING]
 # Set the log level for the output to the terminal/console
@@ -115,6 +171,12 @@ merge_algorithm = default
 # values, so if you set N=10000, it might use any value between
 # 8000 and 12000 for your transactions.
 tx_fees = 3
+
+# Transaction fee rate variance factor, 0.2 means 20% variation around
+# any manually chosen values, so if you set tx_fees=10000 and
+# tx_fees_factor=0.2, it might use any value between 8 thousand and 12 thousand
+# for your transactions.
+tx_fees_factor = 0.2
 
 # For users getting transaction fee estimates over an API,
 # place a sanity check limit on the satoshis-per-kB to be paid.
@@ -180,8 +242,7 @@ max_cj_fee_rel = 0.001
 # will have to broadcast the tx manually (you can take the tx hex from the log
 # or terminal) via some other channel. It is not recommended to choose this
 # option when running schedules/tumbler.
-
-tx_broadcast = self
+tx_broadcast = random-peer
 
 # If makers do not respond while creating a coinjoin transaction,
 # the non-responding ones will be ignored. This is the minimum
@@ -198,6 +259,26 @@ minimum_makers = 4
 # The default is to ALWAYS freeze a utxo to an already used address,
 # whatever the value of it, and this is set with the value -1.
 max_sats_freeze_reuse = -1
+
+# Interest rate used when calculating the value of fidelity bonds created
+# by locking bitcoins in timelocked addresses
+# See also:
+# https://gist.github.com/chris-belcher/87ebbcbb639686057a389acb9ab3e25b#determining-interest-rate-r
+# Set as a real number, i.e. 1 = 100% and 0.01 = 1%
+interest_rate = 0.015
+
+# Some makers run their bots to mix their funds not just to earn money
+# So to improve privacy very slightly takers dont always choose a maker based
+# on his fidelity bond but allow a certain small percentage to be chosen completely
+# randomly without taking into account fidelity bonds
+# This parameter sets how many makers on average will be chosen regardless of bonds
+# A real number, i.e. 1 = 100%, 0.125 = 1/8 = 1 in every 8 makers on average will be bondless
+bondless_makers_allowance = 0.125
+
+# To (strongly) disincentivize Sybil behaviour, the value assessment of the bond
+# is based on the (time value of the bond)^x where x is the bond_value_exponent here,
+# where x > 1. It is a real number (so written as a decimal).
+bond_value_exponent = 1.3
 
 ##############################
 #THE FOLLOWING SETTINGS ARE REQUIRED TO DEFEND AGAINST SNOOPERS.
@@ -271,6 +352,12 @@ tor_control_host = localhost
 # control_host = unix:/var/run/tor/control
 tor_control_port = 9051
 
+# the host/port actually serving the hidden service
+# (note the *virtual port*, that the client uses,
+# is hardcoded to 80):
+onion_serving_host = 127.0.0.1
+onion_serving_port = 8082
+
 # in some exceptional case the HS may be SSL configured,
 # this feature is not yet implemented in code, but here for the
 # future:
@@ -290,10 +377,11 @@ cjfee_r = 0.00002
 cjfee_factor = 0.1
 
 # [satoshis, any integer] / the average transaction fee you're adding to coinjoin transactions
-txfee = 100
+# (note: this will soon be deprecated; leave at zero)
+txfee_contribution = 0
 
 # [fraction, 0-1] / variance around the average fee. Ex: 1000 fee, 0.2 var = fee is btw 800-1200
-txfee_factor = 0.3
+txfee_contribution_factor = 0.3
 
 # [satoshis, any integer] / minimum size of your cj offer. Lower cj amounts will be disregarded
 minsize = 100000
@@ -302,3 +390,22 @@ minsize = 100000
 size_factor = 0.1
 
 gaplimit = 6
+
+[SNICKER]
+# Any other value than 'true' will be treated as False,
+# and no SNICKER actions will be enabled in that case:
+enabled = false
+
+# In satoshis, we require any SNICKER to pay us at least
+# this much (can be negative), otherwise we will refuse
+# to sign it:
+lowest_net_gain = 0
+
+# Comma separated list of servers (if port is omitted as :port, it
+# is assumed to be 80) which we will poll against (all, in sequence); note
+# that they are allowed to be *.onion or cleartext servers, and no
+# scheme (http(s) etc) needs to be added to the start.
+servers = cn5lfwvrswicuxn3gjsxoved6l2gu5hdvwy5l3ev7kg6j7lbji2k7hqd.onion,
+
+# How many minutes between each polling event to each server above:
+polling_interval_minutes = 60


### PR DESCRIPTION
## Description

Updates the jm config file to adhere to v0.9.9 defaults.
This is necessary as some new properties have been added and other ones updated, especially the message servers + communication via directory nodes.

Without this change, users cannot act as taker or maker, since their offers wont be seen by other participants.

See the [default config generated in v0.9.9](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/v0.9.9/jmclient/jmclient/configure.py#L100-L533), or the [default one that is used in jam standalone docker image](https://github.com/joinmarket-webui/jam-docker/blob/v0.1.5-clientserver-v0.9.9/standalone/default.cfg).

## Checklist

* [ ] tested successfully on local MyNode, if yes, list the device(s) below
* [ ] mentioned related open issue, if any

Unfortunately, I am not able to test this. Other users have reportedly updated their config manually and it resolved their issue of not seeing the orderbook.

I don't know if this is the only change necessary, hope someone with more knowledge about mynode setups can make further adaptions on demand if needed.

## List of test device(s)

<!-- Raspi4, Rock64, VM -->
None
