### PR TITLE
Remove deprecatedrpc 'addresses' from bitcoin.conf

### DIFF
--- a/rootfs/standard/usr/share/mynode/bitcoin.conf
+++ b/rootfs/standard/usr/share/mynode/bitcoin.conf
@@ -31,8 +31,7 @@ main.wallet=joinmarket_wallet.dat
 test.wallet=wallet.dat
 test.wallet=joinmarket_wallet.dat
 
-# Enable Deprecated RPCs
-deprecatedrpc=addresses
+# Enable Deprecated RPCs (if any)
 
 # Whitelist local connections (and docker)
 whitelist=127.0.0.1


### PR DESCRIPTION
Apparently this option was removed in bitcoin v23.0 as stated in the [release notes](https://bitcoincore.org/en/releases/23.0/), but it's possible I've overlooked some reason why it might still be useful.

> The -deprecatedrpc=addresses configuration option has been removed. RPCs gettxout, getrawtransaction, decoderawtransaction, decodescript, gettransaction verbose=true and REST endpoints /rest/tx, /rest/getutxos, /rest/block no longer return the addresses and reqSigs fields, which were previously deprecated in 22.0. ([#22650](https://github.com/bitcoin/bitcoin/pull/22650))