### PR TITLE
Update subnet in mempool-docker-compose.yml

### DIFF
--- a/rootfs/standard/usr/share/mynode/mempool-docker-compose.yml
+++ b/rootfs/standard/usr/share/mynode/mempool-docker-compose.yml
@@ -52,4 +52,4 @@ networks:
     ipam:
       driver: default
       config:
-      - subnet:  172.26.0.1/24
+      - subnet:  172.26.0.0/24


### PR DESCRIPTION
Fix for invalid subnet refused by docker-compose at (re)install

## Description

Reinstalling mempool somehow failed. Looking at the log the error came from docker-compose. It denies a subnet of 172.26.0.1/24, the error message said it should be 172.26.0.0/24. So I changed it to this.

## Checklist

* [X] tested successfully on local MyNode

## List of test device(s)

VM Debian 12
