### PR TITLE
samouraiwallet is no more, removing it

### DIFF
--- a/setup/setup_device.sh
+++ b/setup/setup_device.sh
@@ -225,7 +225,6 @@ curl https://raw.githubusercontent.com/JoinMarket-Org/joinmarket-clientserver/ma
 gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 01EA5486DE18A882D4C2684590C8019E36C2E964
 gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys E777299FC265DD04793070EB944D35F9AC3DB76A # Bitcoin - Michael Ford (fanquake)
 curl https://keybase.io/suheb/pgp_keys.asc | gpg --import
-curl https://samouraiwallet.com/pgp.txt | gpg --import # two keys from Samourai team
 gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys DE23E73BFA8A0AD5587D2FCDE80D2F3F311FD87E # Loop (abosworth)
 gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 9FC6B0BFD597A94DBF09708280E5375C094198D8 # Loop (bhandras)
 gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 26984CB69EB8C4A26196F7A4D7D916376026F177 # Lightning Terminal


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Samouraiwallet is no more.  Without this change the setup_device.sh script fails to continue when it fails to download the pgp.txt file.
<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

* [x] tested successfully on local MyNode, if yes, list the device(s) below
* [ ] mentioned related open issue, if any

## List of test device(s)

Debian 12 VM on Proxmox
