### PR TITLE
fix: log2ram can't stop before it's installed

### DIFF
--- a/setup/setup_device.sh
+++ b/setup/setup_device.sh
@@ -454,17 +454,20 @@ npm install -g yarn
 
 # Install Log2Ram
 if [ $IS_RASPI = 1 ] || [ $IS_X86 = 1 ]; then
-    cd /tmp
-    rm -rf log2ram*
-    wget https://github.com/azlux/log2ram/archive/v1.2.2.tar.gz -O log2ram.tar.gz
-    tar -xvf log2ram.tar.gz
-    mv log2ram-* log2ram
-    cd log2ram
-    chmod +x install.sh
-    service log2ram stop
-    ./install.sh
-    cd ~
+    if [ ! -f /usr/local/bin/log2ram ]; then
+        cd /tmp
+        rm -rf log2ram* || true
+        wget https://github.com/azlux/log2ram/archive/v1.2.2.tar.gz -O log2ram.tar.gz
+        tar -xvf log2ram.tar.gz
+        mv log2ram-* log2ram
+        cd log2ram
+        chmod +x install.sh
+        service log2ram stop || true
+        ./install.sh || true
+        cd ~
+    fi
 fi
+
 
 # Remove existing MOTD login info
 rm -rf /etc/motd


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue with `setup/setup_device.sh` where log2ram service would try to stop before log2ram was installed.  I copied the log2ram logic from `rootfs/standard/usr/bin/mynode_post_upgrade.sh` as it looks like it functions correctly.

This is a fix for log2ram not working, and why I opened https://github.com/mynodebtc/mynode/issues/868

## Checklist

* [x] tested successfully on local MyNode, if yes, list the device(s) below
* [x] mentioned related open issue, if any

## List of test device(s)

x86 Debian 12 VM on Proxmox.
