### PR TITLE
LND conf: enable bLIP-50: LSP Spec Transport Layer

### DIFF
--- a/rootfs/standard/usr/share/mynode/lnd.conf
+++ b/rootfs/standard/usr/share/mynode/lnd.conf
@@ -55,6 +55,9 @@ healthcheck.chainbackend.backoff=30s
 ; How often should chain backend checks occur
 healthcheck.chainbackend.interval=5m
 
+[protocol]
+protocol.custom-message=37913
+
 [bolt]
 db.bolt.auto-compact=true
 


### PR DESCRIPTION
LSPS0/bLIP-50 has recently been [merged into the bLIP spec](https://github.com/lightning/blips/blob/master/blip-0050.md). This is a communication protocol over Lightning's p2p messaging layer called BOLT8, and is used for clients to communicate with Lightning Service Providers and vice versa.

At present, LND doesn't allow applications to communicate over BOLT8 with message types higher than 32768, without building with the `dev` tag or modifying the LND configuration. LSPS0/bLIP-50 uses type 37913.

This configuration change will allow MyNode users to interface with LSP spec-compliant services, such as ZEUS' Olympus.

Tested against numerous LND set-ups, but not in MyNode specifically yet.