### PR TITLE
Revert "LND conf: enable bLIP-50: LSP Spec Transport Layer"

### DIFF
--- a/rootfs/standard/usr/share/mynode/lnd.conf
+++ b/rootfs/standard/usr/share/mynode/lnd.conf
@@ -55,9 +55,6 @@ healthcheck.chainbackend.backoff=30s
 ; How often should chain backend checks occur
 healthcheck.chainbackend.interval=5m
 
-[protocol]
-protocol.custom-message=37913
-
 [bolt]
 db.bolt.auto-compact=true
 


### PR DESCRIPTION
Reverts mynodebtc/mynode#892

This caused an LND error.

Feb 25 19:39:40 mynode lnd[537317]: failed to load config: ValidateConfig: custom-message: can't override type: 37913, already in custom range
Feb 25 19:39:40 mynode lnd[537317]: 2025-02-25 19:39:40.059 [WRN] LTND: Error validating config: ValidateConfig: custom-message: can't override type: 37913, already in custom range
