### PR TITLE
Update LNbits v1.0.0-rc10 and change to use docker

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+- Update LNbits to v1.0.0-rc10 and use vendors docker
+
 === v0.3.35 ===
 - Released 03/29/25
 - Add Datum Gateway v0.3.1

--- a/rootfs/standard/usr/bin/mynode_docker_images.sh
+++ b/rootfs/standard/usr/bin/mynode_docker_images.sh
@@ -195,9 +195,8 @@ while true; do
     touch /tmp/need_application_refresh
 
 
-    # Upgrade LNBits
+    # Upgrade LNbits
     if should_install_app "lnbits" ; then
-        LNBITS_UPGRADE_URL=https://github.com/lnbits/lnbits/archive/refs/tags/$LNBITS_VERSION.tar.gz
         CURRENT=""
         if [ -f $LNBITS_VERSION_FILE ]; then
             CURRENT=$(cat $LNBITS_VERSION_FILE)
@@ -205,19 +204,8 @@ while true; do
         if [ "$CURRENT" != "$LNBITS_VERSION" ]; then
             docker rmi $(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'lnbits') || true
 
-            # cd /opt/mynode
-            # rm -rf lnbits
-            # sudo -u bitcoin wget $LNBITS_UPGRADE_URL -O lnbits.tar.gz
-            # sudo -u bitcoin tar -xvf lnbits.tar.gz
-            # sudo -u bitcoin rm lnbits.tar.gz
-            # sudo -u bitcoin mv lnbits-* lnbits
-            # cd lnbits
-
             # Copy over config file
             # Handled in pre_lnbits.sh
-
-            # Build lnbits docker container
-            #docker build --no-cache -t lnbits .
 
             # Pull lnbits docker container
              docker pull lnbits/lnbits:$LNBITS_VERSION

--- a/rootfs/standard/usr/share/mynode/mynode_app_versions.sh
+++ b/rootfs/standard/usr/share/mynode/mynode_app_versions.sh
@@ -132,7 +132,7 @@ BTCRPCEXPLORER_VERSION=$(get_app_version "$BTCRPCEXPLORER_VERSION" "btcrpcexplor
 BTCRPCEXPLORER_VERSION_FILE=/home/bitcoin/.mynode/btcrpcexplorer_version
 BTCRPCEXPLORER_LATEST_VERSION_FILE=/home/bitcoin/.mynode/btcrpcexplorer_version_latest
 
-LNBITS_VERSION="v0.12.12"
+LNBITS_VERSION="v1.0.0-rc10"
 LNBITS_VERSION=$(get_app_version "$LNBITS_VERSION" "lnbits")
 LNBITS_VERSION_FILE=/home/bitcoin/.mynode/lnbits_version
 LNBITS_LATEST_VERSION_FILE=/home/bitcoin/.mynode/lnbits_version_latest

--- a/rootfs/standard/var/www/mynode/templates/about.html
+++ b/rootfs/standard/var/www/mynode/templates/about.html
@@ -87,9 +87,9 @@
                 JoinMarket is copyrighted, licensed under the GPLv3, and comes with no warranty.
             </p>
             <p>
-                <b>LNBits</b><br/>
+                <b>LNbits</b><br/>
                 <a href="https://github.com/lnbits/lnbits">https://github.com/lnbits/lnbits</a><br/>
-                LNBits is copyrighted, licensed under the MIT license, and comes with no warranty.
+                LNbits is copyrighted, licensed under the MIT license, and comes with no warranty.
             </p>
             <p>
                 <b>LND Connect</b><br/>


### PR DESCRIPTION
## Description

Latest 0.xx Beta LNbits before coming 1.0 Release.
Would be good to update too latest version which can maintained also from lnbits.env file.
LNbits is going towards adminUI based management. And heavily so from 1.0 onward.

Changed from tar.gz based to docker which now works well from LNbits.

## Checklist

* [X] tested successfully on local MyNode, if yes, list the device(s) below
* [X] mentioned related open issue, if any - none

## List of test device(s)

Raspi4

## Other
LNbits is not like dynamic apps, but "bolted on" to MyNode. Maybe 1.0 could me made more modern way?
I have LNbits 1.0.0.rc10 on bench too. So it could be quick to add after 1.0 Release.
