### PR TITLE
fix lnd.conf generation with protocol.option-scid-alias

### DIFF
--- a/rootfs/standard/usr/bin/mynode_gen_lnd_config.sh
+++ b/rootfs/standard/usr/bin/mynode_gen_lnd_config.sh
@@ -108,5 +108,5 @@ fi
 
 # Set Alias
 ALIAS=$(cat /mnt/hdd/mynode/settings/.lndalias)
-sed -i "s/alias=.*/alias=$ALIAS/g" /mnt/hdd/mynode/lnd/lnd.conf
+sed -i "s/^alias=.*/alias=$ALIAS/g" /mnt/hdd/mynode/lnd/lnd.conf
 chown bitcoin:bitcoin /mnt/hdd/mynode/lnd/lnd.conf


### PR DESCRIPTION
This patch change the regexp to replace node alias, in order to not interfere with other option with alias in name

## Description

In order to use zero-conf channels, protocol.option-scid-alias must be set to true.
However, lnd.conf generation in mynode would replace "true" with node alias, due to the regexp it use.
See #697 too.

## List of test device(s)

My Debian buster VM.
