### PR TITLE
Settings page improve LNbits super_user view

### DIFF
--- a/rootfs/standard/var/www/mynode/api.py
+++ b/rootfs/standard/var/www/mynode/api.py
@@ -320,13 +320,17 @@ def api_get_lnbits_superuser():
     check_logged_in()
 
     data = {}
-    data["status"] = "error"
     data["data"] = "UNKNOWN"
+    data["status"] = "error"
     try:
-        info = ""
+        info = get_lnbits_superuser_setup() + "\n"
 
-        info += to_string(subprocess.check_output("cat /mnt/hdd/mynode/lnbits/.super_user", shell=True))
-        info += "\n"
+        if not os.path.isfile("/mnt/hdd/mynode/lnbits/database.sqlite3"):
+            info += "LNbits database NOT initialized! super_user details cannot be fetched.\n"
+        else:
+            info += "LNbits super_user configured in database:\n"
+            info += get_lnbits_superuser() + "\n"
+
         data["data"] = info
         data["status"] = "success"
     except Exception as e:

--- a/rootfs/standard/var/www/mynode/templates/settings.html
+++ b/rootfs/standard/var/www/mynode/templates/settings.html
@@ -1260,17 +1260,17 @@
             <a id="lnbits"></a>
             <div class="settings_block_header">LNbits</div>
 
-            <div class="settings_block_subheader">Reset LNbits Settings</div>
+            <div class="settings_block_subheader">Reset Settings</div>
             This will delete your LNbits settings from the database. This should not impact users, wallets and installed extension data. After deletion, LNbits will re-read its default settings from the environment file and save it in the new settings database. This will also reset super user username and password.
             <br/>
             <a href="/settings/delete-lnbits-settings" class="ui-button ui-widget ui-corner-all settings_button">Delete Settings</a>
 
             <div class="divider"></div>
 
-            <div class="settings_block_subheader">Show LNbits superuser ID</div>
-            Show the superuser ID for LNbits. It is needed to access the admin UI.
+            <div class="settings_block_subheader">Show super_user</div>
+            Show LNbits super_user setup and details.
             <br/>
-            <button id="run-lnbits-cli-superuser" class="ui-button ui-widget ui-corner-all settings_button">Show Superuser ID</button>
+            <button id="run-lnbits-cli-superuser" class="ui-button ui-widget ui-corner-all settings_button">Show superuser</button>
             <pre id="run-lnbits-cli-superuser-result"></pre>
         </div>
 


### PR DESCRIPTION
Tested on MyNodeBTC 0.3.35 and lnbits-v1.0.0-rc10

## Enables user to see LNbits super_user settings from .env, file and database

New (as of 2023) databased configuration base scheme relies onto super_user who is setup on LNbits settings database when 
LNBITS_ADMIN_UI=true is LNbits .env configuration file and LNbits is started.
This enhancement helps to see super_user setup stage and username too.

* [X] tested successfully on local MyNode, if yes, list the device(s) below
* [X] mentioned related open issue, if any:
Issues
- https://github.com/mynodebtc/mynode/issues/811
- https://github.com/mynodebtc/mynode/issues/848


## List of test device(s)

- Raspi 4 MyNodeBTC 0.3.35
