### PR TITLE
Add first_install handler to post_lnbits.sh

### DIFF
--- a/rootfs/standard/etc/systemd/system/lnbits.service
+++ b/rootfs/standard/etc/systemd/system/lnbits.service
@@ -12,6 +12,7 @@ ExecStartPre=/usr/bin/is_mainnet.sh
 ExecStartPre=/usr/bin/wait_on_lnd.sh
 ExecStartPre=/usr/bin/wait_on_docker_image_install.sh
 ExecStartPre=/usr/bin/service_scripts/pre_lnbits.sh
+ExecStartPRe=/usr/bin/docker rm -f lnbits
 WorkingDirectory=/opt/mynode/lnbits
 
 ExecStart=/usr/bin/docker run --rm \
@@ -23,14 +24,16 @@ ExecStart=/usr/bin/docker run --rm \
                               --volume /mnt/hdd/mynode/lnd/data/chain/bitcoin/mainnet/admin.macaroon:/app/admin.macaroon \
                               --add-host=host.docker.internal:host-gateway \
                               lnbits
+ExecStartPost=+/usr/bin/service_scripts/post_lnbits.sh
+
 ExecStop=/usr/bin/docker stop -t 2 lnbits
 
 User=bitcoin
 Group=bitcoin
 Type=simple
-TimeoutSec=120
+TimeoutSec=300
 Restart=always
-RestartSec=30
+RestartSec=60
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=lnbits

--- a/rootfs/standard/usr/bin/service_scripts/post_lnbits.sh
+++ b/rootfs/standard/usr/bin/service_scripts/post_lnbits.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+source /usr/share/mynode/mynode_config.sh
+
+set -x
+
+sleep 60s
+
+# should this long code be splitted to own .sh file?
+# handle /first_install if needed
+#
+# Step 1: Retrieve super_user ID and remove quotes
+export SUPER_USER_ID=$(sudo sqlite3 /mnt/hdd/mynode/lnbits/database.sqlite3 \
+    "SELECT value FROM system_settings WHERE id='super_user';" | sed 's/\"//g')
+
+# Step 2: Check if first_install is done for the specific super_user ID
+export FIRST_INSTALL_STATUS=$(sudo sqlite3 /mnt/hdd/mynode/lnbits/database.sqlite3 \
+    "SELECT COUNT(*) FROM accounts WHERE id = '$SUPER_USER_ID' \
+    AND username IS NOT NULL;")
+
+if [[ $FIRST_INSTALL_STATUS -eq 1 ]]; then
+    echo "FIRST_INSTALL done. Get admin details from Settings page."
+else
+    echo "FIRST_INSTALL not completed. Doing now..."
+
+    # Step 3: Make the first_install API call
+    curl -v -X PUT https://127.0.0.1:5001/api/v1/auth/first_install \
+        -H "Content-Type: application/json" \
+        -d '{
+            "username": "admin",
+            "password": "securebolt",
+            "password_repeat": "securebolt"
+        }' \
+        -k
+
+    # Step 4: Update accounts table with correct username and password_hash ("bolt")
+    sudo sqlite3 /mnt/hdd/mynode/lnbits/database.sqlite3 \
+        "UPDATE accounts SET username = 'admin', \
+        password_hash = '\$2b\$12\$GWNtn8GarOLpc5XKMcqFMuY05vIIKWkLtbPSjvqho0P2CLaiNCHHm' \
+        WHERE id = '$SUPER_USER_ID';"
+
+    # remove username and password sql here for debugging
+    # sudo sqlite3 /mnt/hdd/mynode/lnbits/database.sqlite3 \
+    #     "UPDATE accounts SET username = NULL, \
+    #     password_hash = NULL \
+    #     WHERE id = '$SUPER_USER_ID';"
+
+fi


### PR DESCRIPTION
Simulates first_install process with username "admin" and password "bolt" rendering LNbits usable with super_user.

## Description

Change implements rude bypass of LNbits first_install process, which is used to create super_user.
This change handles process on behalf of user with default username and password.
Provides another kind of "additional reset option" asked on https://github.com/mynodebtc/mynode/pull/903

## Checklist

* [X] tested successfully on local MyNode, if yes, list the device(s) below
* [X] mentioned related open issue, if any

## List of test device(s)

Raspi4

## ToDo

Add update of this password also to MyNode password change functions so password would go hand in hand with other apps.