### PR TITLE
Fix LNbits (dockerized) v0.12.12 start

### DIFF
--- a/rootfs/standard/etc/systemd/system/lnbits.service
+++ b/rootfs/standard/etc/systemd/system/lnbits.service
@@ -31,9 +31,8 @@ Type=simple
 TimeoutSec=120
 Restart=always
 RestartSec=30
-# Causes exessive logging now days
-# StandardOutput=syslog
-# StandardError=syslog
+StandardOutput=syslog
+StandardError=syslog
 SyslogIdentifier=lnbits
 
 [Install]

--- a/rootfs/standard/etc/systemd/system/lnbits.service
+++ b/rootfs/standard/etc/systemd/system/lnbits.service
@@ -31,8 +31,9 @@ Type=simple
 TimeoutSec=120
 Restart=always
 RestartSec=30
-StandardOutput=syslog
-StandardError=syslog
+# Causes exessive logging now days
+# StandardOutput=syslog
+# StandardError=syslog
 SyslogIdentifier=lnbits
 
 [Install]

--- a/rootfs/standard/etc/systemd/system/lnbits.service
+++ b/rootfs/standard/etc/systemd/system/lnbits.service
@@ -15,14 +15,14 @@ ExecStartPre=/usr/bin/service_scripts/pre_lnbits.sh
 WorkingDirectory=/opt/mynode/lnbits
 
 ExecStart=/usr/bin/docker run --rm \
-                              --name lnbits \
-                              -p 5000:5000 \
-                              --volume /mnt/hdd/mynode/lnbits/.env:/app/.env \
-                              --volume /mnt/hdd/mynode/lnbits/:/app/data \
-                              --volume /mnt/hdd/mynode/lnd/tls.cert:/app/tls.cert \
-                              --volume /mnt/hdd/mynode/lnd/data/chain/bitcoin/mainnet/admin.macaroon:/app/admin.macaroon \
-                              --add-host=host.docker.internal:host-gateway \
-                              lnbits
+    --name lnbits \
+    -p 5000:5000 \
+    --volume /mnt/hdd/mynode/lnbits/.env:/app/.env \
+    --volume /mnt/hdd/mynode/lnbits/:/app/data \
+    --volume /mnt/hdd/mynode/lnd/tls.cert:/app/tls.cert \
+    --volume /mnt/hdd/mynode/lnd/data/chain/bitcoin/mainnet/admin.macaroon:/app/admin.macaroon \
+    --add-host=host.docker.internal:host-gateway \
+    lnbits
 ExecStop=/usr/bin/docker stop -t 2 lnbits
 
 User=bitcoin

--- a/rootfs/standard/usr/bin/mynode_docker_images.sh
+++ b/rootfs/standard/usr/bin/mynode_docker_images.sh
@@ -204,6 +204,10 @@ while true; do
         if [ "$CURRENT" != "$LNBITS_VERSION" ]; then
             docker rmi $(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'lnbits') || true
 
+            if [ ! -d "/opt/mynode/lnbits" ]; then
+                mkdir -p "/opt/mynode/lnbits"
+            fi
+
             # Copy over config file
             # Handled in pre_lnbits.sh
 


### PR DESCRIPTION
## Description

lnbits.service designates
WorkingDirectory=/opt/mynode/lnbits

New dockerized install doesn't created dir so this fix is needed.

## Checklist

* [X] tested successfully on local MyNode, if yes, list the device(s) below
* [X] mentioned related open issue, if any - see above

## List of test device(s)

Raspi4, VM amd64
