### PR TITLE
Update to post_mempool.sh and mempool-docker-compose.yml

### DIFF
--- a/rootfs/standard/usr/bin/service_scripts/post_mempool.sh
+++ b/rootfs/standard/usr/bin/service_scripts/post_mempool.sh
@@ -6,27 +6,38 @@ source /usr/share/mynode/mynode_config.sh
 
 sleep 10s
 
-# initalize mysql db (REQUIRED TO START MYSQL)
+# Check Docker Compose version
+compose_version=$(docker-compose --version)
+
+if [[ $compose_version == *"v2."* ]]; then
+  separator="-"
+else
+  separator="_"
+fi
+
+export DB_CONTAINER_NAME="mempool${separator}db${separator}1"
+
+# initialize mysql db (REQUIRED TO START mysql)
 isRunning=""
 
-# check on loop if  mysql db is running. when running initialize
+# Check on loop if mysql db is running; when running, initialize
 while [ 1 ]; do
   # Check if mempool mysql db is running (check the db container)
-  isRunning=$(docker inspect --format="{{.State.Running}}" mempool-db-1)
+  isRunning=$(docker inspect --format="{{.State.Running}}" $DB_CONTAINER_NAME)
   if [ "$isRunning" == "true" ]; then
     sleep 5s
 
     # Initialize database
-    databases=$(docker exec -i mempool-db-1 mysql -uroot -padmin -e "SHOW DATABASES;")
+    databases=$(docker exec -i $DB_CONTAINER_NAME mysql -uroot -padmin -e "SHOW DATABASES;")
     if [[ "$databases" == *"information_schema"* ]]; then   # Check DB is responding
         if [[ "$databases" == *"mempool"* ]]; then
             # DB found, exit 0
             exit 0
         else
             # Setup a database for mempool
-            $(docker exec -i mempool-db-1 mysql -uroot -padmin -e "drop database mempool;")
-            $(docker exec -i mempool-db-1 mysql -uroot -padmin -e "create database mempool;")
-            $(docker exec -i mempool-db-1 mysql -uroot -padmin -e "grant all privileges on mempool.* to 'mempool'@'%' identified by 'mempool';")
+            $(docker exec -i $DB_CONTAINER_NAME mysql -uroot -padmin -e "drop database mempool;")
+            $(docker exec -i $DB_CONTAINER_NAME mysql -uroot -padmin -e "create database mempool;")
+            $(docker exec -i $DB_CONTAINER_NAME mysql -uroot -padmin -e "grant all privileges on mempool.* to 'mempool'@'%' identified by 'mempool';")
             exit 0
         fi
     fi

--- a/rootfs/standard/usr/bin/service_scripts/post_mempool.sh
+++ b/rootfs/standard/usr/bin/service_scripts/post_mempool.sh
@@ -12,21 +12,21 @@ isRunning=""
 # check on loop if  mysql db is running. when running initialize
 while [ 1 ]; do
   # Check if mempool mysql db is running (check the db container)
-  isRunning=$(docker inspect --format="{{.State.Running}}" mempool_db_1)
+  isRunning=$(docker inspect --format="{{.State.Running}}" mempool-db-1)
   if [ "$isRunning" == "true" ]; then
     sleep 5s
 
     # Initialize database
-    databases=$(docker exec -i mempool_db_1 mysql -uroot -padmin -e "SHOW DATABASES;")
+    databases=$(docker exec -i mempool-db-1 mysql -uroot -padmin -e "SHOW DATABASES;")
     if [[ "$databases" == *"information_schema"* ]]; then   # Check DB is responding
         if [[ "$databases" == *"mempool"* ]]; then
             # DB found, exit 0
             exit 0
         else
             # Setup a database for mempool
-            $(docker exec -i mempool_db_1 mysql -uroot -padmin -e "drop database mempool;")
-            $(docker exec -i mempool_db_1 mysql -uroot -padmin -e "create database mempool;")
-            $(docker exec -i mempool_db_1 mysql -uroot -padmin -e "grant all privileges on mempool.* to 'mempool'@'%' identified by 'mempool';")
+            $(docker exec -i mempool-db-1 mysql -uroot -padmin -e "drop database mempool;")
+            $(docker exec -i mempool-db-1 mysql -uroot -padmin -e "create database mempool;")
+            $(docker exec -i mempool-db-1 mysql -uroot -padmin -e "grant all privileges on mempool.* to 'mempool'@'%' identified by 'mempool';")
             exit 0
         fi
     fi

--- a/rootfs/standard/usr/share/mynode/mempool-docker-compose.yml
+++ b/rootfs/standard/usr/share/mynode/mempool-docker-compose.yml
@@ -6,6 +6,8 @@ services:
         FRONTEND_HTTP_PORT: "8080"
         BACKEND_MAINNET_HTTP_HOST: "api"
     image: mempool/frontend:${VERSION}
+# user defined on mempool v3.0.0 docker-compose.yml
+#    user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     command: "./wait-for db:3306 --timeout=720 -- nginx -g 'daemon off;'"
@@ -28,6 +30,10 @@ services:
         DATABASE_PASSWORD: "mempool"
         STATISTICS_ENABLED: "true"
     image: mempool/backend:${VERSION}
+# user defined on mempool v3.0.0 docker-compose.yml
+#    user: "1000:1000"
+# would correct format here now be?
+#    user: "0:0"
     user: 0:0
     restart: on-failure
     stop_grace_period: 1m
@@ -41,6 +47,8 @@ services:
         MYSQL_PASSWORD: "mempool"
         MYSQL_ROOT_PASSWORD: "admin"
     image: ${MARIA_DB_IMAGE}
+# user defined on mempool v3.0.0 docker-compose.yml
+#    user: "1000:1000"
     restart: on-failure
     stop_grace_period: 1m
     volumes:


### PR DESCRIPTION
from issue https://github.com/mynodebtc/mynode/issues/920

## Description

Database startup check script is looking for containers with naming convention of old docker compose v1.
(was thinking that: Newer mempool wants some user definations onto compose.yml - but not true)

## Checklist

* [X] tested PoC (successfully) on local MyNode, if yes, list the device(s) below
* [X] mentioned related open issue, if any

## List of test device(s)

Raspi4

migrate changes from mempool v3.0.0 .yml
still errors need to fix correctly and testing
One time I got mempool site up with command
```
cd /opt/mynode/mempool
/usr/local/bin/docker-compose up

```