### PR TITLE
Add Raspberry Pi Compute Module 5 support

### DIFF
--- a/rootfs/standard/usr/share/mynode/mynode_app_versions.sh
+++ b/rootfs/standard/usr/share/mynode/mynode_app_versions.sh
@@ -17,7 +17,7 @@ function get_app_version()
 }
 
 BTC_VERSION="28.1"
-if [ "$DEBIAN_VERSION" -lt "12" ]; then
+if [ "$DEBIAN_VER_NUM" -lt "12" ]; then
     BTC_VERSION="27.2"
 fi
 BTC_VERSION=$(get_app_version "$BTC_VERSION" "bitcoin")

--- a/rootfs/standard/usr/share/mynode/mynode_device_info.sh
+++ b/rootfs/standard/usr/share/mynode/mynode_device_info.sh
@@ -43,7 +43,7 @@ elif [[ $MODEL == *"Raspberry Pi 4"* ]]; then
         IS_32_BIT=0
         IS_64_BIT=1
     fi
-elif [[ $MODEL == *"Raspberry Pi 5"* ]]; then
+elif [[ $MODEL == *"Raspberry Pi 5"* || $MODEL == *"Raspberry Pi Compute Module 5"* ]]; then
     IS_RASPI=1
     IS_RASPI5=1
     IS_ARM64=1

--- a/rootfs/standard/usr/share/mynode/mynode_device_info.sh
+++ b/rootfs/standard/usr/share/mynode/mynode_device_info.sh
@@ -74,4 +74,4 @@ TOTAL_RAM_GB=$(free --giga | grep Mem | awk '{print $2}')
 
 SERIAL_NUM=$(mynode-get-device-serial)
 
-DEBIAN_VERSION=$(lsb_release -r -s)
+DEBIAN_VER_NUM=$(lsb_release -r -s)

--- a/setup/setup_device.sh
+++ b/setup/setup_device.sh
@@ -54,7 +54,7 @@ elif [[ $MODEL == *"Raspberry Pi 4"* ]]; then
         IS_32_BIT=0
         IS_64_BIT=1
     fi
-elif [[ $MODEL == *"Raspberry Pi 5"* ]]; then
+elif [[ $MODEL == *"Raspberry Pi 5"* || $MODEL == *"Raspberry Pi Compute Module 5"* ]]; then
     IS_RASPI=1
     IS_RASPI5=1
     IS_ARM64=1


### PR DESCRIPTION
This PR adds support for the Raspberry Pi Compute Module 5 (CM5) by updating the platform detection logic in setup_device.sh and rootfs\standard\usr\share\mynode\mynode_device_info.sh. The CM5's model string ("Raspberry Pi Compute Module 5 Lite Rev 1.0") was not recognized, causing MyNode to treat it as an unknown device. Changes:

- Added pattern match for "Raspberry Pi Compute Module 5" in the Raspberry Pi 5 condition.
- Preserves compatibility with all other supported devices (Rock64, Raspberry Pi 3/4, etc.).
