### PR TITLE
Update bitcoin_info.py - remove .batch_

### DIFF
--- a/rootfs/standard/var/pynode/bitcoin_info.py
+++ b/rootfs/standard/var/pynode/bitcoin_info.py
@@ -120,8 +120,8 @@ def update_bitcoin_other_info():
             if mynode_block_height != bitcoin_recent_blocks_last_cache_height:
                 commands = [ [ "getblockhash", height] for height in range(mynode_block_height-9, mynode_block_height+1) ]
                 try:
-                    block_hashes = rpc_connection.batch_(commands)
-                    bitcoin_recent_blocks = rpc_connection.batch_([ [ "getblock", h ] for h in block_hashes ])
+                    block_hashes = [rpc_connection.getblockhash(cmd[1]) for cmd in commands]
+                    bitcoin_recent_blocks = [rpc_connection.getblock(h) for h in block_hashes]
                     bitcoin_recent_blocks_last_cache_height = mynode_block_height
                 except Exception as e_block:
                     log_message("ERROR: getblockhash batch command failure " + str(e_block))


### PR DESCRIPTION
## Description

For some reason .batch processing leads to exception and log error:
`May 05 21:39:48 mynode www[191052]: [2025-05-05 21:39:48,172] INFO in utilities: ERROR: getblockhash batch command failure 'error'
`

and `api/get_bitcoin_info` gives `"recent_blocks":null`

`{"block_height":895405,"current_block":895405,"mempool_size":"0.47 MB","peer_count":11,"progress":"100.00%","recent_blocks":null,"recommended_fees":"Low priority: 1 sat/vB &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Medium priority: 1 sat/vB &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; High priority: 1 sat/vB"}
`

## Checklist

* [X] tested successfully on local MyNode, if yes, list the device(s) below
* [X] mentioned related open issue, if any: https://github.com/mynodebtc/mynode/issues/927

## List of test device(s)

VM amd64 Debian 12 python 3.8.9 (Version 0.3.35 + beta_04-30-25_1746075262)

This fix is not needed on:
Raspi 4B MyNodeBTC v0.3.35 with python 3.11.2