### PR TITLE
Update about.html - Remove links to samourai.io

### DIFF
--- a/rootfs/standard/var/www/mynode/templates/about.html
+++ b/rootfs/standard/var/www/mynode/templates/about.html
@@ -126,7 +126,7 @@
                 <a href="https://github.com/Ride-The-Lightning/RTL">https://github.com/Ride-The-Lightning/RTL</a><br/>
                 RTL is copyrighted, licensed under the MIT license, and comes with no warranty.
             </p>
-            <p>
+<!--            <p>
                 <b>Samourai Dojo</b><br/>
                 <a href="https://code.samourai.io/dojo/samourai-dojo">https://code.samourai.io/dojo/samourai-dojo</a><br/>
                 Samourai Dojo is copyrighted, licensed under the AGPLv3, and comes with no warranty.
@@ -136,6 +136,7 @@
                 <a href="https://code.samourai.io/whirlpool/whirlpool-client-cli">https://code.samourai.io/whirlpool/whirlpool-client-cli</a><br/>
                 Samourai Whirlpool is copyrighted, licensed under the AGPLv3, and comes with no warranty.
             </p>
+-->
             <p>
                 <b>Specter Desktop</b><br/>
                 <a href="https://github.com/cryptoadvance/specter-desktop">https://github.com/cryptoadvance/specter-desktop</a><br/>


### PR DESCRIPTION
samourai.io is no longer owned by the dead project and links forward unsolidated pages.
