### PR TITLE
AMD64 fix to node info detectors.

### DIFF
--- a/rootfs/standard/usr/share/mynode/mynode_device_info.sh
+++ b/rootfs/standard/usr/share/mynode/mynode_device_info.sh
@@ -19,7 +19,7 @@ MODEL="unknown"
 if [ -f /proc/device-tree/model ]; then
     MODEL=$(tr -d '\0' < /proc/device-tree/model) || MODEL="unknown"
 fi
-uname -a | grep amd64 && IS_X86=1 && IS_64_BIT=1 || true
+uname -a | grep -E 'amd64|x86_64' && IS_X86=1 && IS_64_BIT=1 || true
 if [[ $MODEL == *"Rock64"* ]]; then 
     IS_ARMBIAN=1
     IS_ROCK64=1

--- a/setup/setup_device.sh
+++ b/setup/setup_device.sh
@@ -31,7 +31,7 @@ IS_UNKNOWN=0
 DEVICE_TYPE="unknown"
 MODEL=$(cat /proc/device-tree/model) || IS_UNKNOWN=1
 DEBIAN_CODENAME=$(lsb_release -c -s) || DEBIAN_CODENAME="unknown"
-uname -a | grep amd64 && IS_X86=1 && IS_64_BIT=1 && IS_UNKNOWN=0 || true
+uname -a | grep -E 'amd64|x86_64' && IS_X86=1 && IS_64_BIT=1 && IS_UNKNOWN=0 || true
 if [[ $MODEL == *"Rock64"* ]]; then
     IS_ARMBIAN=1
     IS_ROCK64=1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This allows for the installation of MyNode under Qubes OS and other systems that don't have a kernel which says "amd64".

## Checklist

* [x] tested successfully on local MyNode, if yes, list the device(s) below
* [ ] mentioned related open issue, if any

## List of test device(s)

VM.
