### PR TITLE
Make LNbits v1.x extensions persistent

### DIFF
--- a/rootfs/standard/usr/bin/service_scripts/pre_lnbits.sh
+++ b/rootfs/standard/usr/bin/service_scripts/pre_lnbits.sh
@@ -16,6 +16,11 @@ if [ ! -f /mnt/hdd/mynode/lnbits/update_config_$LNBITS_CONFIG_UPDATE_NUM ]; then
     touch /mnt/hdd/mynode/lnbits/update_config_$LNBITS_CONFIG_UPDATE_NUM
 fi
 
+# Make folder for persistent extensions
+if [ ! -d "/mnt/hdd/mynode/lnbits/extensions" ]; then
+    mkdir -p "/mnt/hdd/mynode/lnbits/extensions"
+fi
+
 # Generate hex macaroons
 #macaroonAdminHex=$(xxd -ps -u -c 1000 /mnt/hdd/mynode/lnd/data/chain/bitcoin/mainnet/admin.macaroon)
 

--- a/rootfs/standard/usr/share/mynode/lnbits.env
+++ b/rootfs/standard/usr/share/mynode/lnbits.env
@@ -75,3 +75,6 @@ LND_REST_CERT="/app/tls.cert"
 LND_REST_MACAROON=FILL_IN
 # To use an AES-encrypted macaroon, set 
 # LND_REST_MACAROON_ENCRYPTED="eNcRyPtEdMaCaRoOn"
+
+# Define extensions path for docker persistent location
+LNBITS_EXTENSIONS_PATH="./data"


### PR DESCRIPTION
Fixes https://github.com/mynodebtc/mynode/issues/939

Based on instructions from LNbits updated documentation;
https://github.com/lnbits/lnbits/blob/c1f0ad66fe834cb30d9246bb7d438ccb6189c3b3/docs/guide/installation.md#option-4-docker

## Description

This change fixes issue where LNbits extensions are extracted (by default) inside of docker. As dockers are stopped with "rm" the image is discarded and installed extension files are deleted too. After restart files are extracted again. Extraction is by default done to "upgrades" folder and some extensions use path in configurations, which causes many issues.

## Checklist

* [X] tested successfully on local MyNode, if yes, list the device(s) below
* [X] mentioned related open issue, if any: https://github.com/mynodebtc/mynode/issues/939

## List of test device(s)

Raspi4

## Additional notes

This should be merged quickly, as Premium version on MyNode now supports Custom versions install up to LNbits v1.2.1, and all v1.x suffer from non-persistent extension issues. Also this is (IMHO) mandatory before MyNode LNbits upgrades to Release versions of v1.x .