### PR TITLE
update Knots to v29.2.knots20251110

### DIFF
--- a/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
+++ b/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
@@ -199,6 +199,28 @@ elif [ "$APP" = "knots_29_2" ]; then
     echo "29.2-knots" > /mnt/hdd/mynode/settings/bitcoin_version_latest_custom
 
     cd ~
+elif [ "$APP" = "knots_29_2_2" ]; then
+    BTC_UPGRADE_URL=https://bitcoinknots.org/files/29.x/29.2.knots20251110/bitcoin-29.2.knots20251110-$ARCH.tar.gz
+    BTC_SHASUM=https://bitcoinknots.org/files/29.x/29.2.knots20251110/SHA256SUMS
+    BTC_ASC=https://bitcoinknots.org/files/29.x/29.2.knots20251110/SHA256SUMS.asc
+
+    rm -rf /opt/download
+    mkdir -p /opt/download
+    cd /opt/download
+
+    # Download, install and verify
+    wget $BTC_UPGRADE_URL $BTC_SHASUM $BTC_ASC
+    gpg --verify SHA256SUMS.asc SHA256SUMS
+    sha256sum -c SHA256SUMS --ignore-missing
+    tar -xvf bitcoin-29.2.knots20251110-$ARCH.tar.gz
+    mv bitcoin-29.2.knots20251110 bitcoin
+    install -m 0755 -o root -g root -t /usr/local/bin bitcoin/bin/*
+
+    echo "29.2.2-knots" > /home/bitcoin/.mynode/bitcoin_version
+    echo "29.2.2-knots" > /home/bitcoin/.mynode/bitcoin_version_latest_custom
+    echo "29.2.2-knots" > /mnt/hdd/mynode/settings/bitcoin_version_latest_custom
+
+    cd ~
 elif [ "$APP" = "default" ]; then
     # Clear custom info and re-install bitcoin
     echo "unknown" > /home/bitcoin/.mynode/bitcoin_version

--- a/rootfs/standard/var/www/mynode/templates/settings.html
+++ b/rootfs/standard/var/www/mynode/templates/settings.html
@@ -1109,9 +1109,10 @@
                 <option value="none" selected="selected">Choose...</option>
                 <option value="none">--- Recommended ---</option>
                 <option value="default">Default</option>
+                <option value="knots_29_2_2" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.2.knots20251110)</option>
+                <option value="none">--- Old / Not Recommended ---</option>
                 <option value="knots_29_2" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.2)</option>
                 <option value="knots_29_1" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.1)</option>
-                <option value="none">--- Old / Not Recommended ---</option>
                 <option value="knots_28_1" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v28.1)</option>
                 <option value="knots_27_1">Bitcoin Knots (v27.1)</option>
                 <option value="knots_26_1">Bitcoin Knots (v26.1)</option>


### PR DESCRIPTION
Moving all older versions of Knots to old because of DDOS vectors

## Checklist

* [x] tested successfully on local MyNode, if yes, list the device(s) below

## List of test device(s)

VM
