### PR TITLE
Bitcoin Knots + BIP-110 RC3

### DIFF
--- a/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
+++ b/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
@@ -19,6 +19,7 @@ APP="$1"
 # Import GPG keys specific to Custom Bitcoin versions
 set +e
 gpg --keyserver keys.openpgp.org --recv-keys CACC7CBB26B3D2EE8FC2F2BC0E37EBAB8574F005   # Leo Haf (Knots)
+gpg --keyserver keyserver.ubuntu.com --recv-keys 2B97F03293744D70F6BBA82F2E3A66FF67F98B4F   # Dathon Ohm (BIP-110)
 set -e
 
 # Determine arch
@@ -219,6 +220,28 @@ elif [ "$APP" = "knots_29_2_2" ]; then
     echo "29.2.2-knots" > /home/bitcoin/.mynode/bitcoin_version
     echo "29.2.2-knots" > /home/bitcoin/.mynode/bitcoin_version_latest_custom
     echo "29.2.2-knots" > /mnt/hdd/mynode/settings/bitcoin_version_latest_custom
+
+    cd ~
+elif [ "$APP" = "bip110" ]; then
+    BTC_UPGRADE_URL=https://github.com/dathonohm/bitcoin/releases/download/v29.2.knots20251110%2Bbip110-v0.1rc3/bitcoin-29.2.knots20251110+bip110-v0.1rc3-$ARCH.tar.gz
+    BTC_SHASUM=https://raw.githubusercontent.com/dathonohm/guix.sigs/refs/heads/bip110/29.2.knots20251110%2Bbip110-v0.1rc3/dathonohm/all.SHA256SUMS
+    BTC_ASC=https://raw.githubusercontent.com/dathonohm/guix.sigs/refs/heads/bip110/29.2.knots20251110%2Bbip110-v0.1rc3/dathonohm/all.SHA256SUMS.asc
+
+    rm -rf /opt/download
+    mkdir -p /opt/download
+    cd /opt/download
+
+    # Download, install and verify
+    wget $BTC_UPGRADE_URL $BTC_SHASUM $BTC_ASC
+    gpg --verify all.SHA256SUMS.asc all.SHA256SUMS
+    sha256sum -c all.SHA256SUMS --ignore-missing
+    tar -xvf bitcoin-29.2.knots20251110+bip110-v0.1rc3-$ARCH.tar.gz
+    mv bitcoin-29.2.knots20251110+bip110-v0.1rc3 bitcoin
+    install -m 0755 -o root -g root -t /usr/local/bin bitcoin/bin/*
+
+    echo "bip110" > /home/bitcoin/.mynode/bitcoin_version
+    echo "bip110" > /home/bitcoin/.mynode/bitcoin_version_latest_custom
+    echo "bip110" > /mnt/hdd/mynode/settings/bitcoin_version_latest_custom
 
     cd ~
 elif [ "$APP" = "default" ]; then

--- a/rootfs/standard/var/www/mynode/templates/settings.html
+++ b/rootfs/standard/var/www/mynode/templates/settings.html
@@ -1109,6 +1109,7 @@
                 <option value="none" selected="selected">Choose...</option>
                 <option value="none">--- Recommended ---</option>
                 <option value="default">Default</option>
+                <option value="bip110" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots + BIP-110</option>
                 <option value="knots_29_2_2" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.2.knots20251110)</option>
                 <option value="none">--- Old / Not Recommended ---</option>
                 <option value="knots_29_2" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.2)</option>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds [Release Candidate 3](https://github.com/dathonohm/bitcoin/releases/tag/v29.2.knots20251110%2Bbip110-v0.1rc3) of the BIP-110 Reduced_data Temporary Softfork official activation client.

It replaces [the PR for RC2](https://github.com/mynodebtc/mynode/pull/982). The only difference is that all of the references to RC2 have been updated to RC3.

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

* [x] tested successfully on local MyNode, if yes, list the device(s) below

## List of test device(s)

<!-- Raspi4, Rock64, VM -->

VM
