### PR TITLE
BIP-110 v0.1

### DIFF
--- a/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
+++ b/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
@@ -42,6 +42,10 @@ fi
 curl -s "https://api.github.com/repos/bitcoinknots/guix.sigs/contents/builder-keys" |
 jq -r '.[].download_url' | while read url; do curl -s "$url" | gpg --import; done
 
+# Install BIP110 keys
+curl -s "https://api.github.com/repos/dathonohm/guix.sigs/contents/builder-keys" |
+jq -r '.[].download_url' | while read url; do curl -s "$url" | gpg --import; done
+
 # Custom re-install steps
 if [ "$APP" = "ordisrespector" ]; then
     apt-get install -y build-essential libtool autotools-dev automake pkg-config bsdmainutils python3
@@ -223,9 +227,9 @@ elif [ "$APP" = "knots_29_2_2" ]; then
 
     cd ~
 elif [ "$APP" = "bip110" ]; then
-    BTC_UPGRADE_URL=https://github.com/dathonohm/bitcoin/releases/download/v29.2.knots20251110%2Bbip110-v0.1rc3/bitcoin-29.2.knots20251110+bip110-v0.1rc3-$ARCH.tar.gz
-    BTC_SHASUM=https://raw.githubusercontent.com/dathonohm/guix.sigs/refs/heads/bip110/29.2.knots20251110%2Bbip110-v0.1rc3/dathonohm/all.SHA256SUMS
-    BTC_ASC=https://raw.githubusercontent.com/dathonohm/guix.sigs/refs/heads/bip110/29.2.knots20251110%2Bbip110-v0.1rc3/dathonohm/all.SHA256SUMS.asc
+    BTC_UPGRADE_URL=https://github.com/dathonohm/bitcoin/releases/download/v29.2.knots20251110%2Bbip110-v0.1/bitcoin-29.2.knots20251110+bip110-v0.1-$ARCH.tar.gz
+    BTC_SHASUM=https://github.com/dathonohm/bitcoin/releases/download/v29.2.knots20251110%2Bbip110-v0.1/SHA256SUMS
+    BTC_ASC=https://github.com/dathonohm/bitcoin/releases/download/v29.2.knots20251110%2Bbip110-v0.1/SHA256SUMS.asc
 
     rm -rf /opt/download
     mkdir -p /opt/download
@@ -233,10 +237,10 @@ elif [ "$APP" = "bip110" ]; then
 
     # Download, install and verify
     wget $BTC_UPGRADE_URL $BTC_SHASUM $BTC_ASC
-    gpg --verify all.SHA256SUMS.asc all.SHA256SUMS
-    sha256sum -c all.SHA256SUMS --ignore-missing
-    tar -xvf bitcoin-29.2.knots20251110+bip110-v0.1rc3-$ARCH.tar.gz
-    mv bitcoin-29.2.knots20251110+bip110-v0.1rc3 bitcoin
+    gpg --verify SHA256SUMS.asc SHA256SUMS
+    sha256sum -c SHA256SUMS --ignore-missing
+    tar -xvf bitcoin-29.2.knots20251110+bip110-v0.1-$ARCH.tar.gz
+    mv bitcoin-29.2.knots20251110+bip110-v0.1 bitcoin
     install -m 0755 -o root -g root -t /usr/local/bin bitcoin/bin/*
 
     echo "bip110" > /home/bitcoin/.mynode/bitcoin_version

--- a/rootfs/standard/var/www/mynode/templates/settings.html
+++ b/rootfs/standard/var/www/mynode/templates/settings.html
@@ -1099,7 +1099,7 @@
             Installing a new version may take a long time and will reboot the device. To undo a previous change, select Default.
             Using a custom version may break other features and applications or require configuration changes to work properly.
             <br/><br/>
-            Caution: Some custom versions may lead to a hard fork in Bitcoin which could result in lost Lightning funds. Only install versions you trust and are familiar with.
+            "Caution: When BIP-110 activates, running an out-of-consensus software version could leave your node vulnerable to accepting invalid blocks, which could result in lost funds. Only install versions you trust and are familiar with."
             <br/><br/>
             {% if debian_version < 12 %}
             <b>Note: </b>Some custom Bitcoin versions are not supported on Debian 11 or older. You can re-flash your OS drive to 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the BIP-110 Custom Bitcoin Version to the first official production release, [v0.1](https://github.com/dathonohm/bitcoin/releases/tag/v29.2.knots20251110%2Bbip110-v0.1).

It also updates the warning about Custom Bitcoin Versions to remove references to "hard forks", which presumably refers to BIP-110 and is incorrect.

Users _should_ be aware that there is risk of funds loss, but running the custom BIP-110 client is not necessarily the only way to incur this risk, and in fact, _not_ running it may ultimately be the most risky action.

I included further details in the commit message:

```
BIP-110 can neither lead to a "hard fork", nor will it likely lead to
loss of Lightning funds. In the unlikely event of a chainsplit, all
Lightning-related transactions would be valid on both chains, and
the BIP-110 client is based on Knots, which does not ban peers that
send invalid blocks. This means there would be no network partition,
meaning that all nodes will continue to see all Lightning-related
transactions and will be able to respond appropriately.

It should be noted that the greatest risk arises for nodes who don't
update to enforce the new rules. These nodes risk following an
incoherent chain that keeps being wiped out. Since miners mining on
such an incoherent chain would waste enormous amounts of revenue,
this scenario is implausible.
```
<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Checklist

* [x] tested successfully on local MyNode, if yes, list the device(s) below

## List of test device(s)

<!-- Raspi4, Rock64, VM -->

VM
