### PR TITLE
Add version tag to BIP-110 in dropdown menu

### DIFF
--- a/rootfs/standard/var/www/mynode/templates/settings.html
+++ b/rootfs/standard/var/www/mynode/templates/settings.html
@@ -1117,7 +1117,7 @@
                 <option value="none" selected="selected">Choose...</option>
                 <option value="none">--- Recommended ---</option>
                 <option value="default">Default</option>
-                <option value="bip110" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots + BIP-110</option>
+                <option value="bip110" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots + BIP-110 (v29.3.knots20260210+bip110-v0.3)</option>
                 <option value="knots_29_3" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.3.knots20260210)</option>
                 <option value="none">--- Old / Not Recommended ---</option>
                 <option value="knots_29_2_2" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.2.knots20251110)</option>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds the version tag to the BIP-110 option in the node dropdown menu.

Requested here: https://github.com/mynodebtc/mynode/pull/992#issuecomment-3924119118

Here is how it looks:
<img width="1336" height="1130" alt="bip110-version-tag" src="https://github.com/user-attachments/assets/1a2c6e2a-4667-4298-9048-b391938ec553" />


## Checklist

* [x] tested successfully on local MyNode, if yes, list the device(s) below
* [x] mentioned related open issue, if any

## List of test device(s)

VM
