### PR TITLE
Update BIP-110 to v0.4.1

### DIFF
--- a/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
+++ b/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
@@ -249,9 +249,9 @@ elif [ "$APP" = "knots_29_3" ]; then
 
     cd ~
 elif [ "$APP" = "bip110" ]; then
-    BTC_UPGRADE_URL=https://github.com/dathonohm/bitcoin/releases/download/v29.3.knots20260210%2Bbip110-v0.3/bitcoin-29.3.knots20260210+bip110-v0.3-$ARCH.tar.gz
-    BTC_SHASUM=https://github.com/dathonohm/bitcoin/releases/download/v29.3.knots20260210%2Bbip110-v0.3/SHA256SUMS
-    BTC_ASC=https://github.com/dathonohm/bitcoin/releases/download/v29.3.knots20260210%2Bbip110-v0.3/SHA256SUMS.asc
+    BTC_UPGRADE_URL=https://github.com/dathonohm/bitcoin/releases/download/v29.3.knots20260210%2Bbip110-v0.4.1/bitcoin-29.3.knots20260210+bip110-v0.4.1-$ARCH.tar.gz
+    BTC_SHASUM=https://github.com/dathonohm/bitcoin/releases/download/v29.3.knots20260210%2Bbip110-v0.4.1/SHA256SUMS
+    BTC_ASC=https://github.com/dathonohm/bitcoin/releases/download/v29.3.knots20260210%2Bbip110-v0.4.1/SHA256SUMS.asc
 
     rm -rf /opt/download
     mkdir -p /opt/download
@@ -261,8 +261,8 @@ elif [ "$APP" = "bip110" ]; then
     wget $BTC_UPGRADE_URL $BTC_SHASUM $BTC_ASC
     gpg --verify SHA256SUMS.asc SHA256SUMS
     sha256sum -c SHA256SUMS --ignore-missing
-    tar -xvf bitcoin-29.3.knots20260210+bip110-v0.3-$ARCH.tar.gz
-    mv bitcoin-29.3.knots20260210+bip110-v0.3 bitcoin
+    tar -xvf bitcoin-29.3.knots20260210+bip110-v0.4.1-$ARCH.tar.gz
+    mv bitcoin-29.3.knots20260210+bip110-v0.4.1 bitcoin
     install -m 0755 -o root -g root -t /usr/local/bin bitcoin/bin/*
 
     echo "bip110" > /home/bitcoin/.mynode/bitcoin_version

--- a/rootfs/standard/var/www/mynode/templates/settings.html
+++ b/rootfs/standard/var/www/mynode/templates/settings.html
@@ -1117,7 +1117,7 @@
                 <option value="none" selected="selected">Choose...</option>
                 <option value="none">--- Recommended ---</option>
                 <option value="default">Bitcoin Core (default)</option>
-                <option value="bip110" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots + BIP-110 (v29.3 + v0.3)</option>
+                <option value="bip110" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots + BIP-110 (v29.3 + v0.4.1)</option>
                 <option value="knots_29_3" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.3)</option>
                 <option value="none">--- Old / Not Recommended ---</option>
                 <option value="knots_29_2_2" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.2.2)</option>


### PR DESCRIPTION
## Description

This updates the BIP-110 activation client to v0.4.1. See [the release notes](https://github.com/dathonohm/bitcoin/releases/tag/v29.3.knots20260210%2Bbip110-v0.4.1) for further details.
## Checklist

* [x] tested successfully on local MyNode, if yes, list the device(s) below

## List of test device(s)

VM