### PR TITLE
Update knots to v29.3.knots20260508

### DIFF
--- a/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
+++ b/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
@@ -294,6 +294,28 @@ elif [ "$APP" = "knots_29_3" ]; then
     echo "29.3-knots" > /mnt/hdd/mynode/settings/bitcoin_version_latest_custom
 
     cd ~
+elif [ "$APP" = "knots_29_3_2" ]; then
+    BTC_UPGRADE_URL=https://bitcoinknots.org/files/29.x/29.3.knots20260210/bitcoin-29.3.knots20260210-$ARCH.tar.gz
+    BTC_SHASUM=https://bitcoinknots.org/files/29.x/29.3.knots20260210/SHA256SUMS
+    BTC_ASC=https://bitcoinknots.org/files/29.x/29.3.knots20260210/SHA256SUMS.asc
+
+    rm -rf /opt/download
+    mkdir -p /opt/download
+    cd /opt/download
+
+    # Download, install and verify
+    wget $BTC_UPGRADE_URL $BTC_SHASUM $BTC_ASC
+    gpg --verify SHA256SUMS.asc SHA256SUMS
+    sha256sum -c SHA256SUMS --ignore-missing
+    tar -xvf bitcoin-29.3.knots20260210-$ARCH.tar.gz
+    mv bitcoin-29.3.knots20260210 bitcoin
+    install -m 0755 -o root -g root -t /usr/local/bin bitcoin/bin/*
+
+    echo "29.3.2-knots" > /home/bitcoin/.mynode/bitcoin_version
+    echo "29.3.2-knots" > /home/bitcoin/.mynode/bitcoin_version_latest_custom
+    echo "29.3.2-knots" > /mnt/hdd/mynode/settings/bitcoin_version_latest_custom
+
+    cd ~
 elif [ "$APP" = "default" ]; then
     # Clear custom info and re-install bitcoin
     echo "unknown" > /home/bitcoin/.mynode/bitcoin_version

--- a/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
+++ b/rootfs/standard/usr/bin/mynode-install-custom-bitcoin
@@ -63,10 +63,10 @@ fi
 
 # Custom re-install steps
 if [ "$APP" = "bip110_autoupdate" ]; then
-    BIP110_LATEST_VERSION="bip110-v0.4.1" # Must be unique each version (only used to track trigger upgrade)
-    BTC_UPGRADE_URL=https://github.com/dathonohm/bitcoin/releases/download/v29.3.knots20260210%2Bbip110-v0.4.1/bitcoin-29.3.knots20260210+bip110-v0.4.1-$ARCH.tar.gz
-    BTC_SHASUM=https://github.com/dathonohm/bitcoin/releases/download/v29.3.knots20260210%2Bbip110-v0.4.1/SHA256SUMS
-    BTC_ASC=https://github.com/dathonohm/bitcoin/releases/download/v29.3.knots20260210%2Bbip110-v0.4.1/SHA256SUMS.asc
+    BIP110_LATEST_VERSION="29.3.3-knots" # Must be unique each version (only used to track trigger upgrade)
+    BTC_UPGRADE_URL=https://bitcoinknots.org/files/29.x/29.3.knots20260507/bitcoin-29.3.knots20260508-$ARCH.tar.gz
+    BTC_SHASUM=https://bitcoinknots.org/files/29.x/29.3.knots20260508/SHA256SUMS
+    BTC_ASC=https://bitcoinknots.org/files/29.x/29.3.knots20260508/SHA256SUMS.asc
 
     CURRENT=""
     if [ -f $CUSTOM_BITCOIN_AUTOUPDATE_VERSION_FILE ]; then
@@ -81,8 +81,8 @@ if [ "$APP" = "bip110_autoupdate" ]; then
         wget $BTC_UPGRADE_URL $BTC_SHASUM $BTC_ASC
         gpg --verify SHA256SUMS.asc SHA256SUMS
         sha256sum -c SHA256SUMS --ignore-missing
-        tar -xvf bitcoin-29.3.knots20260210+bip110-v0.4.1-$ARCH.tar.gz
-        mv bitcoin-29.3.knots20260210+bip110-v0.4.1 bitcoin
+        tar -xvf bitcoin-29.3.knots20260508-$ARCH.tar.gz
+        mv bitcoin-29.3.knots20260508 bitcoin
         install -m 0755 -o root -g root -t /usr/local/bin bitcoin/bin/*
     fi
     echo "bip110_autoupdate" > /home/bitcoin/.mynode/bitcoin_version
@@ -91,10 +91,10 @@ if [ "$APP" = "bip110_autoupdate" ]; then
     echo "$BIP110_LATEST_VERSION" > $CUSTOM_BITCOIN_AUTOUPDATE_VERSION_FILE
     cd ~
 elif [ "$APP" = "knots_autoupdate" ]; then
-    KNOTS_LATEST_VERSION="29.3-knots" # Must be unique each version (only used to track trigger upgrade)
-    BTC_UPGRADE_URL=https://bitcoinknots.org/files/29.x/29.3.knots20260210/bitcoin-29.3.knots20260210-$ARCH.tar.gz
-    BTC_SHASUM=https://bitcoinknots.org/files/29.x/29.3.knots20260210/SHA256SUMS
-    BTC_ASC=https://bitcoinknots.org/files/29.x/29.3.knots20260210/SHA256SUMS.asc
+    KNOTS_LATEST_VERSION="29.3.2-knots" # Must be unique each version (only used to track trigger upgrade)
+    BTC_UPGRADE_URL=https://bitcoinknots.org/files/29.x/29.3.knots20260507/bitcoin-29.3.knots20260507-$ARCH.tar.gz
+    BTC_SHASUM=https://bitcoinknots.org/files/29.x/29.3.knots20260507/SHA256SUMS
+    BTC_ASC=https://bitcoinknots.org/files/29.x/29.3.knots20260507/SHA256SUMS.asc
 
     CURRENT=""
     if [ -f $CUSTOM_BITCOIN_AUTOUPDATE_VERSION_FILE ]; then
@@ -109,8 +109,8 @@ elif [ "$APP" = "knots_autoupdate" ]; then
         wget $BTC_UPGRADE_URL $BTC_SHASUM $BTC_ASC
         gpg --verify SHA256SUMS.asc SHA256SUMS
         sha256sum -c SHA256SUMS --ignore-missing
-        tar -xvf bitcoin-29.3.knots20260210-$ARCH.tar.gz
-        mv bitcoin-29.3.knots20260210 bitcoin
+        tar -xvf bitcoin-29.3.knots20260507-$ARCH.tar.gz
+        mv bitcoin-29.3.knots20260507 bitcoin
         install -m 0755 -o root -g root -t /usr/local/bin bitcoin/bin/*
     fi
     echo "knots_autoupdate" > /home/bitcoin/.mynode/bitcoin_version
@@ -292,6 +292,50 @@ elif [ "$APP" = "knots_29_3" ]; then
     echo "29.3-knots" > /home/bitcoin/.mynode/bitcoin_version
     echo "29.3-knots" > /home/bitcoin/.mynode/bitcoin_version_latest_custom
     echo "29.3-knots" > /mnt/hdd/mynode/settings/bitcoin_version_latest_custom
+
+    cd ~
+elif [ "$APP" = "knots_29_3_2" ]; then
+    BTC_UPGRADE_URL=https://bitcoinknots.org/files/29.x/29.3.knots20260507/bitcoin-29.3.knots20260507-$ARCH.tar.gz
+    BTC_SHASUM=https://bitcoinknots.org/files/29.x/29.3.knots20260507/SHA256SUMS
+    BTC_ASC=https://bitcoinknots.org/files/29.x/29.3.knots20260507/SHA256SUMS.asc
+
+    rm -rf /opt/download
+    mkdir -p /opt/download
+    cd /opt/download
+
+    # Download, install and verify
+    wget $BTC_UPGRADE_URL $BTC_SHASUM $BTC_ASC
+    gpg --verify SHA256SUMS.asc SHA256SUMS
+    sha256sum -c SHA256SUMS --ignore-missing
+    tar -xvf bitcoin-29.3.knots20260507-$ARCH.tar.gz
+    mv bitcoin-29.3.knots20260507 bitcoin
+    install -m 0755 -o root -g root -t /usr/local/bin bitcoin/bin/*
+
+    echo "29.3.2-knots" > /home/bitcoin/.mynode/bitcoin_version
+    echo "29.3.2-knots" > /home/bitcoin/.mynode/bitcoin_version_latest_custom
+    echo "29.3.2-knots" > /mnt/hdd/mynode/settings/bitcoin_version_latest_custom
+
+    cd ~
+elif [ "$APP" = "knots_29_3_3" ]; then
+    BTC_UPGRADE_URL=https://bitcoinknots.org/files/29.x/29.3.knots20260508/bitcoin-29.3.knots20260508-$ARCH.tar.gz
+    BTC_SHASUM=https://bitcoinknots.org/files/29.x/29.3.knots20260508/SHA256SUMS
+    BTC_ASC=https://bitcoinknots.org/files/29.x/29.3.knots20260508/SHA256SUMS.asc
+
+    rm -rf /opt/download
+    mkdir -p /opt/download
+    cd /opt/download
+
+    # Download, install and verify
+    wget $BTC_UPGRADE_URL $BTC_SHASUM $BTC_ASC
+    gpg --verify SHA256SUMS.asc SHA256SUMS
+    sha256sum -c SHA256SUMS --ignore-missing
+    tar -xvf bitcoin-29.3.knots20260508-$ARCH.tar.gz
+    mv bitcoin-29.3.knots20260508 bitcoin
+    install -m 0755 -o root -g root -t /usr/local/bin bitcoin/bin/*
+
+    echo "29.3.3-knots" > /home/bitcoin/.mynode/bitcoin_version
+    echo "29.3.3-knots" > /home/bitcoin/.mynode/bitcoin_version_latest_custom
+    echo "29.3.3-knots" > /mnt/hdd/mynode/settings/bitcoin_version_latest_custom
 
     cd ~
 elif [ "$APP" = "default" ]; then

--- a/rootfs/standard/usr/bin/mynode_startup.sh
+++ b/rootfs/standard/usr/bin/mynode_startup.sh
@@ -539,6 +539,11 @@ echo "BITCOIN_GID=$BITCOIN_GID" >> /mnt/hdd/mynode/settings/.btcrpc_environment
 # Reset BTCARGS
 echo "BTCARGS=" > /mnt/hdd/mynode/bitcoin/env
 
+CHECK_CONSENSUS=$(cat /home/bitcoin/.mynode/bitcoin_version | head -n 1)
+if [ "$CHECK_CONSENSUS" == "29.3.2-knots" ]; then
+    echo "BTCARGS=-consensusrules=rdts" > /mnt/hdd/mynode/bitcoin/env
+fi
+
 
 # Set proper permissions on drive
 USER=$(stat -c '%U' /mnt/hdd/mynode/quicksync)

--- a/rootfs/standard/usr/bin/mynode_startup.sh
+++ b/rootfs/standard/usr/bin/mynode_startup.sh
@@ -539,6 +539,11 @@ echo "BITCOIN_GID=$BITCOIN_GID" >> /mnt/hdd/mynode/settings/.btcrpc_environment
 # Reset BTCARGS
 echo "BTCARGS=" > /mnt/hdd/mynode/bitcoin/env
 
+CHECK_CONSENSUS=$(cat /home/bitcoin/.mynode/bitcoin_version | head -n 1)
+if [ "$CHECK_CONSENSUS" == "29.3.3-knots" ]; then
+    echo "BTCARGS=-consensusrules=rdts" > /mnt/hdd/mynode/bitcoin/env
+fi
+
 
 # Set proper permissions on drive
 USER=$(stat -c '%U' /mnt/hdd/mynode/quicksync)

--- a/rootfs/standard/var/www/mynode/templates/settings.html
+++ b/rootfs/standard/var/www/mynode/templates/settings.html
@@ -513,7 +513,21 @@
                     disabled: true
                 });
                 $("#custom_bitcoin_install_button").on("click", function() {
-                    window.location.href='/settings/install-custom-bitcoin?version='+custom_bitcoin_choice
+                    if (custom_bitcoin_choice == "knots_29_3_2") {
+                        var okFunction = function() {
+                            window.location.href='/settings/install-custom-bitcoin?version='+custom_bitcoin_choice
+                        }
+                        openConfirmDialog("confirm-dialog",
+                                          "Custom Bitcoin Version",
+                                          "<p>This release adds enforcement of the one-year \"reduced data\" protocol change to the Bitcoin rules, beginning no later than September.</p>" +
+                                          "<p>Protocol changes require user consent to be effective, and if enforced inconsistently within the community may compromise your security or others!</p>" +
+                                          "<p>If you do not know what you are doing, you can learn more at https://bitcoinknots.org/learn/2026-rdts</p>" +
+                                          "<p>Note that to reject this softfork, you must implement your own rejection fork.</p>" +
+                                          "<p>Are you sure you want to install this version?</p>",
+                                          okFunction)
+                    } else {
+                        window.location.href='/settings/install-custom-bitcoin?version='+custom_bitcoin_choice
+                    }
                 });
 
                 $("#logout_days").selectmenu({width: 70});
@@ -1124,6 +1138,7 @@
                 <option value="default">Bitcoin Core (default)</option>
                 <option value="bip110_autoupdate" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots + BIP-110 (latest)</option>
                 <option value="knots_autoupdate" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (latest)</option>
+                <option value="knots_29_3_2" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.3.knots20260416rc1)</option>
                 <option value="knots_29_3" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.3)</option>
                 <option value="none">--- Old / Not Recommended ---</option>
                 <option value="knots_29_2_2" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.2.2)</option>

--- a/rootfs/standard/var/www/mynode/templates/settings.html
+++ b/rootfs/standard/var/www/mynode/templates/settings.html
@@ -513,7 +513,20 @@
                     disabled: true
                 });
                 $("#custom_bitcoin_install_button").on("click", function() {
-                    window.location.href='/settings/install-custom-bitcoin?version='+custom_bitcoin_choice
+                    if (custom_bitcoin_choice == "knots_29_3_3") {
+                        var okFunction = function() {
+                            window.location.href='/settings/install-custom-bitcoin?version='+custom_bitcoin_choice
+                        }
+                        openConfirmDialog("confirm-dialog",
+                                          "Custom Bitcoin Version",
+                                          "<p>This version of Bitcoin Knots applies the BIP110 (RDTS) network upgrade, which fixes critical vulnerabilities in long-standing network design. To avoid applying this upgrade by accident, this version asks for explicit confirmation.</p>" +
+                                          "<p>Important: Because this upgrade already has broad community support, skipping this update or reverting to an older software version does not reject it. Running outdated software after any network upgrade only leaves your node vulnerable to displaying fake or fraudulent transactions. To effectively reject this upgrade, you need to run alternative software designed to split away from the upgraded network.<p>" +
+                                          "<p>If you do not know what you are doing, you can learn more at https://bitcoinknots.org/learn/2026-rdts</p>" +
+                                          "<p>Do you want to install this version?</p>",
+                                          okFunction)
+                    } else {
+                        window.location.href='/settings/install-custom-bitcoin?version='+custom_bitcoin_choice
+                    }
                 });
 
                 $("#logout_days").selectmenu({width: 70});
@@ -1124,8 +1137,10 @@
                 <option value="default">Bitcoin Core (default)</option>
                 <option value="bip110_autoupdate" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots + BIP-110 (latest)</option>
                 <option value="knots_autoupdate" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (latest)</option>
-                <option value="knots_29_3" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.3)</option>
+                <option value="knots_29_3_3" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.3.knots20260508)</option>
+                <option value="knots_29_3_2" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.3.knots20260507)</option>
                 <option value="none">--- Old / Not Recommended ---</option>
+                <option value="knots_29_3" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.3)</option>
                 <option value="knots_29_2_2" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.2.2)</option>
                 <option value="knots_29_1" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v29.1)</option>
                 <option value="knots_28_1" {% if debian_version < 12 %}disabled{% endif %}>Bitcoin Knots (v28.1)</option>


### PR DESCRIPTION
@tehelsper this change will be for the next version of Knots (URL aren't updated yet since there is no official release), since SF should never happen in a auto update I'm not sure how to handle `knots_autoupdate`, we can either not provide it the auto update or prompt the user something once he install the new version of mynode.
Let me know how you want to proceed!

## Description

Add a prompt to inform the user that the new Knots release add consensus rules changes, the user must confirm to install the new version.

## Checklist

* [x] tested successfully on local MyNode, if yes, list the device(s) below
* [x] mentioned related open issue, if any

## List of test device(s)

VM
