### PR TITLE
Update Canary packaging for v1.5.0 and local explorers

### DIFF
--- a/rootfs/standard/usr/share/mynode_apps/canary/app_data/docker-compose.yml
+++ b/rootfs/standard/usr/share/mynode_apps/canary/app_data/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   backend:
-    image: schjonhaug/canary-backend:v1.5.0
+    image: canary-backend:latest
     network_mode: host
     restart: unless-stopped
     stop_grace_period: 30s
@@ -18,7 +18,7 @@ services:
       CANARY_BIND_ADDRESS: 127.0.0.1:3004
 
   frontend:
-    image: schjonhaug/canary-frontend:v1.5.0
+    image: canary-frontend:latest
     network_mode: host
     restart: unless-stopped
     stop_grace_period: 30s

--- a/rootfs/standard/usr/share/mynode_apps/canary/app_data/docker-compose.yml
+++ b/rootfs/standard/usr/share/mynode_apps/canary/app_data/docker-compose.yml
@@ -2,12 +2,14 @@ version: "3.8"
 
 services:
   backend:
-    image: canary-backend:latest
+    image: schjonhaug/canary-backend:v1.5.0
     network_mode: host
     restart: unless-stopped
     stop_grace_period: 30s
     volumes:
       - /mnt/hdd/mynode/canary:/app/data
+    env_file:
+      - /mnt/hdd/mynode/canary/canary.env
     environment:
       CANARY_DATA_DIR: /app/data
       CANARY_ELECTRUM_URL: tcp://127.0.0.1:50001
@@ -16,7 +18,7 @@ services:
       CANARY_BIND_ADDRESS: 127.0.0.1:3004
 
   frontend:
-    image: canary-frontend:latest
+    image: schjonhaug/canary-frontend:v1.5.0
     network_mode: host
     restart: unless-stopped
     stop_grace_period: 30s

--- a/rootfs/standard/usr/share/mynode_apps/canary/canary.json
+++ b/rootfs/standard/usr/share/mynode_apps/canary/canary.json
@@ -29,6 +29,8 @@
     "app_tile_name": "Canary",
     "app_tile_running_status_text": "Monitoring",
     "app_tile_default_status_text": "Wallet Monitor",
+    "app_tile_button_text": "Open",
+    "app_tile_button_href": "/app/canary/info",
     "app_tile_button_open_app_directly": true,
     "can_uninstall": true,
     "can_reinstall": true,

--- a/rootfs/standard/usr/share/mynode_apps/canary/canary.json
+++ b/rootfs/standard/usr/share/mynode_apps/canary/canary.json
@@ -16,7 +16,7 @@
         "Get instant notifications when your bitcoins move via ntfy push notifications.",
         "Features include: transaction monitoring, RBF/CPFP detection, balance alerts, and deep wallet scanning."
     ],
-    "latest_version": "v1.4.0",
+    "latest_version": "v1.5.0",
     "supported_archs": ["amd64", "arm64"],
     "download_skip": true,
     "requires_docker_image_installation": true,

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
@@ -9,11 +9,15 @@ set -e
 
 echo "==================== INSTALLING APP ===================="
 
+APP_DIR="/opt/mynode/canary"
+VERSION="${VERSION:-v1.4.0}"
+
 mkdir -p /opt/mynode/canary || true
 mkdir -p /mnt/hdd/mynode/canary || true
 
-cp -f app_data/docker-compose.yml docker-compose.yml
+cp -f "$APP_DIR/app_data/docker-compose.yml" "$APP_DIR/docker-compose.yml"
 
+cd "$APP_DIR"
 /usr/local/bin/docker-compose down --remove-orphans 2>/dev/null || true
 
 remove_docker_images_by_name "canary-backend"

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
@@ -19,7 +19,7 @@ version: "3.8"
 
 services:
   backend:
-    image: schjonhaug/canary-backend:$VERSION
+    image: canary-backend:latest
     network_mode: host
     restart: unless-stopped
     stop_grace_period: 30s
@@ -35,7 +35,7 @@ services:
       CANARY_BIND_ADDRESS: 127.0.0.1:3004
 
   frontend:
-    image: schjonhaug/canary-frontend:$VERSION
+    image: canary-frontend:latest
     network_mode: host
     restart: unless-stopped
     stop_grace_period: 30s
@@ -54,6 +54,15 @@ write_compose_file
 
 cd "$APP_DIR"
 /usr/local/bin/docker-compose down --remove-orphans 2>/dev/null || true
+
+remove_docker_images_by_name "canary-backend"
+remove_docker_images_by_name "canary-frontend"
+
+docker pull schjonhaug/canary-backend:$VERSION
+docker pull schjonhaug/canary-frontend:$VERSION
+
+docker tag schjonhaug/canary-backend:$VERSION canary-backend:latest
+docker tag schjonhaug/canary-frontend:$VERSION canary-frontend:latest
 
 echo "$VERSION" > "$VERSION_FILE"
 chown bitcoin:bitcoin "$VERSION_FILE"

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
@@ -10,24 +10,54 @@ set -e
 echo "==================== INSTALLING APP ===================="
 
 APP_DIR="/opt/mynode/canary"
-VERSION="${VERSION:-v1.4.0}"
+VERSION="${VERSION:-v1.5.0}"
+VERSION_FILE="/mnt/hdd/mynode/settings/canary_version"
+
+write_compose_file() {
+    cat > "$APP_DIR/docker-compose.yml" <<EOF
+version: "3.8"
+
+services:
+  backend:
+    image: schjonhaug/canary-backend:$VERSION
+    network_mode: host
+    restart: unless-stopped
+    stop_grace_period: 30s
+    volumes:
+      - /mnt/hdd/mynode/canary:/app/data
+    env_file:
+      - /mnt/hdd/mynode/canary/canary.env
+    environment:
+      CANARY_DATA_DIR: /app/data
+      CANARY_ELECTRUM_URL: tcp://127.0.0.1:50001
+      CANARY_NETWORK: mainnet
+      CANARY_MODE: self-hosted
+      CANARY_BIND_ADDRESS: 127.0.0.1:3004
+
+  frontend:
+    image: schjonhaug/canary-frontend:$VERSION
+    network_mode: host
+    restart: unless-stopped
+    stop_grace_period: 30s
+    depends_on:
+      - backend
+    environment:
+      API_URL: http://127.0.0.1:3004
+      PORT: "3005"
+EOF
+}
 
 mkdir -p /opt/mynode/canary || true
 mkdir -p /mnt/hdd/mynode/canary || true
 
-cp -f "$APP_DIR/app_data/docker-compose.yml" "$APP_DIR/docker-compose.yml"
+write_compose_file
 
 cd "$APP_DIR"
 /usr/local/bin/docker-compose down --remove-orphans 2>/dev/null || true
 
-remove_docker_images_by_name "canary-backend"
-remove_docker_images_by_name "canary-frontend"
-
-docker pull schjonhaug/canary-backend:$VERSION
-docker pull schjonhaug/canary-frontend:$VERSION
-
-docker tag schjonhaug/canary-backend:$VERSION canary-backend:latest
-docker tag schjonhaug/canary-frontend:$VERSION canary-frontend:latest
+echo "$VERSION" > "$VERSION_FILE"
+chown bitcoin:bitcoin "$VERSION_FILE"
+touch /tmp/need_application_refresh
 
 chown -R bitcoin:bitcoin /mnt/hdd/mynode/canary
 

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
@@ -2,8 +2,10 @@
 
 set -e
 
+APP_DIR="/opt/mynode/canary"
+
 # Keep the compose file in sync with the packaged app data.
-cp -f app_data/docker-compose.yml docker-compose.yml
+cp -f "$APP_DIR/app_data/docker-compose.yml" "$APP_DIR/docker-compose.yml"
 
 # Ensure data directory exists before starting.
 mkdir -p /mnt/hdd/mynode/canary

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
@@ -3,10 +3,70 @@
 set -e
 
 APP_DIR="/opt/mynode/canary"
+DATA_DIR="/mnt/hdd/mynode/canary"
+VERSION_FILE="/mnt/hdd/mynode/settings/canary_version"
+VERSION="${VERSION:-$(cat "$VERSION_FILE" 2>/dev/null || echo v1.5.0)}"
+ADMIN_PASSWORD_FILE="$DATA_DIR/admin_password"
+JWT_SECRET_FILE="$DATA_DIR/jwt_secret"
+ENV_FILE="$DATA_DIR/canary.env"
 
-# Keep the compose file in sync with the packaged app data.
-cp -f "$APP_DIR/app_data/docker-compose.yml" "$APP_DIR/docker-compose.yml"
+write_compose_file() {
+    mkdir -p "$APP_DIR"
+    cat > "$APP_DIR/docker-compose.yml" <<EOF
+version: "3.8"
+
+services:
+  backend:
+    image: schjonhaug/canary-backend:$VERSION
+    network_mode: host
+    restart: unless-stopped
+    stop_grace_period: 30s
+    volumes:
+      - /mnt/hdd/mynode/canary:/app/data
+    env_file:
+      - /mnt/hdd/mynode/canary/canary.env
+    environment:
+      CANARY_DATA_DIR: /app/data
+      CANARY_ELECTRUM_URL: tcp://127.0.0.1:50001
+      CANARY_NETWORK: mainnet
+      CANARY_MODE: self-hosted
+      CANARY_BIND_ADDRESS: 127.0.0.1:3004
+
+  frontend:
+    image: schjonhaug/canary-frontend:$VERSION
+    network_mode: host
+    restart: unless-stopped
+    stop_grace_period: 30s
+    depends_on:
+      - backend
+    environment:
+      API_URL: http://127.0.0.1:3004
+      PORT: "3005"
+EOF
+}
+
+generate_secret() {
+    local length="$1"
+    tr -dc A-Za-z0-9 < /dev/urandom | head -c "$length"
+}
+
+write_compose_file
 
 # Ensure data directory exists before starting.
-mkdir -p /mnt/hdd/mynode/canary
-chown -R bitcoin:bitcoin /mnt/hdd/mynode/canary
+mkdir -p "$DATA_DIR"
+
+if [ ! -s "$ADMIN_PASSWORD_FILE" ]; then
+    generate_secret 32 > "$ADMIN_PASSWORD_FILE"
+fi
+
+if [ ! -s "$JWT_SECRET_FILE" ]; then
+    generate_secret 64 > "$JWT_SECRET_FILE"
+fi
+
+cat > "$ENV_FILE" <<EOF
+CANARY_SELF_HOSTED_ADMIN_PASSWORD=$(cat "$ADMIN_PASSWORD_FILE")
+JWT_SECRET=$(cat "$JWT_SECRET_FILE")
+EOF
+
+chown -R bitcoin:bitcoin "$DATA_DIR"
+chmod 600 "$ADMIN_PASSWORD_FILE" "$JWT_SECRET_FILE" "$ENV_FILE"

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
@@ -81,5 +81,9 @@ if service_is_enabled btcrpcexplorer; then
     echo "CANARY_BTC_RPC_EXPLORER_PORT=3002" >> "$ENV_FILE"
 fi
 
+if service_is_enabled mempool || service_is_enabled btcrpcexplorer; then
+    echo "CANARY_TX_EXPLORER_PLATFORM=mynode" >> "$ENV_FILE"
+fi
+
 chown -R bitcoin:bitcoin "$DATA_DIR"
 chmod 600 "$ADMIN_PASSWORD_FILE" "$JWT_SECRET_FILE" "$ENV_FILE"

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
@@ -17,7 +17,7 @@ version: "3.8"
 
 services:
   backend:
-    image: schjonhaug/canary-backend:$VERSION
+    image: canary-backend:latest
     network_mode: host
     restart: unless-stopped
     stop_grace_period: 30s
@@ -33,7 +33,7 @@ services:
       CANARY_BIND_ADDRESS: 127.0.0.1:3004
 
   frontend:
-    image: schjonhaug/canary-frontend:$VERSION
+    image: canary-frontend:latest
     network_mode: host
     restart: unless-stopped
     stop_grace_period: 30s

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
@@ -50,6 +50,11 @@ generate_secret() {
     tr -dc A-Za-z0-9 < /dev/urandom | head -c "$length"
 }
 
+service_is_enabled() {
+    local service_name="$1"
+    systemctl is-enabled "$service_name" > /dev/null 2>&1
+}
+
 write_compose_file
 
 # Ensure data directory exists before starting.
@@ -67,6 +72,14 @@ cat > "$ENV_FILE" <<EOF
 CANARY_SELF_HOSTED_ADMIN_PASSWORD=$(cat "$ADMIN_PASSWORD_FILE")
 JWT_SECRET=$(cat "$JWT_SECRET_FILE")
 EOF
+
+if service_is_enabled mempool; then
+    echo "CANARY_MEMPOOL_PORT=4080" >> "$ENV_FILE"
+fi
+
+if service_is_enabled btcrpcexplorer; then
+    echo "CANARY_BTC_RPC_EXPLORER_PORT=3002" >> "$ENV_FILE"
+fi
 
 chown -R bitcoin:bitcoin "$DATA_DIR"
 chmod 600 "$ADMIN_PASSWORD_FILE" "$JWT_SECRET_FILE" "$ENV_FILE"

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/uninstall_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/uninstall_canary.sh
@@ -8,7 +8,10 @@ set -x
 
 echo "==================== UNINSTALLING APP ===================="
 
-cp -f app_data/docker-compose.yml docker-compose.yml 2>/dev/null || true
+APP_DIR="/opt/mynode/canary"
+
+cp -f "$APP_DIR/app_data/docker-compose.yml" "$APP_DIR/docker-compose.yml" 2>/dev/null || true
+cd "$APP_DIR" 2>/dev/null || true
 /usr/local/bin/docker-compose down --remove-orphans 2>/dev/null || true
 
 

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/uninstall_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/uninstall_canary.sh
@@ -9,15 +9,23 @@ set -x
 echo "==================== UNINSTALLING APP ===================="
 
 APP_DIR="/opt/mynode/canary"
+VERSION_FILE="/mnt/hdd/mynode/settings/canary_version"
+
+remove_canary_images() {
+    docker images --format '{{.Repository}}:{{.Tag}}' \
+        | grep -E '^(canary-backend|canary-frontend|schjonhaug/canary-backend|schjonhaug/canary-frontend):' \
+        | xargs -r docker rmi 2>/dev/null || true
+}
 
 cp -f "$APP_DIR/app_data/docker-compose.yml" "$APP_DIR/docker-compose.yml" 2>/dev/null || true
 cd "$APP_DIR" 2>/dev/null || true
 /usr/local/bin/docker-compose down --remove-orphans 2>/dev/null || true
 
 
-remove_docker_images_by_name "canary-backend"
-remove_docker_images_by_name "canary-frontend"
+remove_canary_images
 
+rm -f "$VERSION_FILE"
 rm -rf /mnt/hdd/mynode/canary
+touch /tmp/need_application_refresh
 
 echo "================== DONE UNINSTALLING APP ================="

--- a/rootfs/standard/usr/share/mynode_apps/canary/www/python/canary.py
+++ b/rootfs/standard/usr/share/mynode_apps/canary/www/python/canary.py
@@ -2,9 +2,27 @@ from flask import Blueprint, render_template
 from user_management import check_logged_in
 from application_info import get_application, get_application_status, get_application_status_color
 from device_info import read_ui_settings
+import os
 
 
 mynode_canary = Blueprint("mynode_canary", __name__)
+
+CANARY_PASSWORD_FILE = "/mnt/hdd/mynode/canary/admin_password"
+CANARY_VERSION_FILE = "/mnt/hdd/mynode/settings/canary_version"
+
+
+def get_canary_password():
+    if not os.path.isfile(CANARY_PASSWORD_FILE):
+        return ""
+    with open(CANARY_PASSWORD_FILE, "r") as password_file:
+        return password_file.read().strip()
+
+
+def get_canary_current_version():
+    if not os.path.isfile(CANARY_VERSION_FILE):
+        return None
+    with open(CANARY_VERSION_FILE, "r") as version_file:
+        return version_file.read().strip()[0:16]
 
 
 @mynode_canary.route("/info")
@@ -12,6 +30,10 @@ def canary_page():
     check_logged_in()
 
     app = get_application("canary")
+    current_version = get_canary_current_version()
+    if current_version:
+        app["current_version"] = current_version
+
     app_status = get_application_status("canary")
     app_status_color = get_application_status_color("canary")
 
@@ -21,5 +43,7 @@ def canary_page():
         "app_status": app_status,
         "app_status_color": app_status_color,
         "app": app,
+        "canary_username": "admin@local",
+        "canary_password": get_canary_password(),
     }
-    return render_template("/app/generic_app.html", **template_data)
+    return render_template("/app/canary/canary.html", **template_data)

--- a/rootfs/standard/usr/share/mynode_apps/canary/www/templates/canary.html
+++ b/rootfs/standard/usr/share/mynode_apps/canary/www/templates/canary.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html lang="en">
+    <head>
+        <title>{{app.name}}</title>
+        {% include 'includes/head.html' %}
+
+        <script src="{{ url_for('static', filename='js/manage_apps.js')}}"></script>
+
+        <style>
+            .canary_credentials_value {
+                font-family: monospace;
+                word-break: break-all;
+            }
+            .canary_credentials_missing {
+                color: #888;
+            }
+        </style>
+
+        <script>
+        $(document).ready(function() {
+            $("#show_canary_password").on("click", function() {
+                $("#show_canary_password").hide(0);
+                $("#canary_password").show();
+                $("#copy_canary_password").show();
+            });
+
+            $("#copy_canary_password").on("click", function() {
+                var password = "{{canary_password}}";
+                function showCopied() {
+                    showAlertPopup("alert_popup", "<b>Password copied!</b>");
+                }
+                function showFailed() {
+                    showAlertPopup("alert_popup", "<b>Password copy failed!</b>");
+                }
+
+                if (navigator.clipboard && window.isSecureContext) {
+                    navigator.clipboard.writeText(password).then(showCopied, showFailed);
+                    return;
+                }
+
+                var input = document.createElement("input");
+                input.value = password;
+                document.body.appendChild(input);
+                input.select();
+                try {
+                    document.execCommand("copy") ? showCopied() : showFailed();
+                } catch (e) {
+                    showFailed();
+                }
+                document.body.removeChild(input);
+            });
+        });
+        </script>
+    </head>
+    <body>
+        {% include 'includes/logo_header.html' %}
+        <div class="mynode_top_left_div">
+            <a href="/"><img class="mynode_nav_icon" src="{{ url_for('static', filename="images/home.png")}}"/></a>
+        </div>
+
+        <div class="main_header">{{app.name}}</div>
+        <br/>
+
+        <div class="app_page_container">
+            <div class="app_page_block_header">&nbsp;</div>
+            <div class="app_page_block_contents">
+
+                <div class="app_page_block_contents_left">
+                    <img class="app_page_icon" src="{{ url_for('static', filename="images/app_icons/")}}{{app.short_name}}.png"/>
+                    {% if not app.hide_status_icon %}
+                    <div class="app_page_status_bar {{app_status_color}}"></div>
+                    {% endif %}
+                    <p style="font-size: 14px; text-align: center;">{{app_status}}</p>
+
+                    <br/>
+
+                    {% if not app.is_installed %}
+                        <button class="ui-button ui-widget ui-corner-all mynode_button app_page_button install_button" onclick="install('{{ app.name }}', '{{ app.short_name }}');">Install</button>
+                    {% else %}
+
+                        {% if app.is_enabled and app.app_page_show_open_button %}
+                            {% if app.http_port != "" or app.https_port != "" %}
+                                <button class="ui-button ui-widget ui-corner-all mynode_button app_page_button" onclick="open_app_in_new_tab('{{app.http_port}}', '{{app.https_port}}', false, '{{app.tor_address}}')">Open</button>
+
+                                <div class="divider button_divider"></div>
+                            {% endif %}
+                        {% endif %}
+
+                        {% if app.is_enabled %}
+                            <button class="ui-button ui-widget ui-corner-all mynode_button app_page_button" onclick="restart_app_via_api('{{ app.name }}', '{{ app.short_name }}');">Restart</button>
+
+                            {% if app.is_enabled and app.data_manageable %}
+                                <button class="ui-button ui-widget ui-corner-all mynode_button app_page_button" onclick="reset_data_folder_via_api('{{ app.name }}', '{{ app.short_name }}');">Reset Data</button>
+                            {% endif %}
+
+                            {% for btn in app.app_page_additional_buttons %}
+                                <button class="ui-button ui-widget ui-corner-all mynode_button app_page_button"
+                                    {% if btn.href is defined and btn.href != "" %}
+                                        onclick="window.location='{{btn.href}}'"
+                                    {% elif btn.onclick is defined and btn.onclick != "" %}
+                                        onclick="{{btn.onclick|safe}}"
+                                    {% endif %}
+                                        >{{btn.title}}</button>
+                            {% endfor %}
+
+                            <div class="divider button_divider"></div>
+                        {% endif %}
+
+                        {% if app.can_enable_disable %}
+                            {% if not app.is_enabled %}
+                                <button class="ui-button ui-widget ui-corner-all mynode_button app_page_button" onclick="toggleEnabled('{{app.short_name}}', '{{app.name}}', true)">Enable</button>
+                            {% else %}
+                                <button class="ui-button ui-widget ui-corner-all mynode_button app_page_button" onclick="toggleEnabled('{{app.short_name}}', '{{app.name}}', false)">Disable</button>
+                            {% endif %}
+                        {% endif %}
+                    {% endif %}
+
+                </div>
+
+                <div class="app_page_block_contents_right">
+                    <div class="app_page_block_contents_heading">
+                        <div class="info-page-block">Info</div>
+                    </div>
+                    <div class="app_page_block_contents_text">
+                        <table class="info_table" style="font-size: 12px; margin-left: 10px">
+                            <tr>
+                                <th>Installed Version</th>
+                                <td>
+                                    {% if app.is_installed %}
+                                        {{app.current_version}}
+                                    {% else %}
+                                        Not Installed
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% if app.author.name is defined %}
+                            <tr>
+                                <th>Author</th>
+                                <td>
+                                    {% if app.author.link is defined and app.author.link != "" %}
+                                        <a href="{{app.author.link}}" target="_blank">{{app.author.name}}</a>
+                                    {% else %}
+                                        {{app.author.name}}
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endif %}
+                            {% if app.website.name is defined and app.website.link is defined %}
+                            <tr>
+                                <th>Website</th>
+                                <td>
+                                    <a href="{{app.website.link}}" target="_blank">{{app.website.name}}</a>
+                                </td>
+                            </tr>
+                            {% endif %}
+                        </table>
+                    </div>
+
+                    <div class="app_page_block_contents_heading">
+                        <div class="info-page-block">Credentials</div>
+                    </div>
+                    <div class="app_page_block_contents_text">
+                        <table class="info_table" style="font-size: 12px; margin-left: 10px">
+                            <tr>
+                                <th>Username</th>
+                                <td><span class="canary_credentials_value">{{canary_username}}</span></td>
+                            </tr>
+                            <tr>
+                                <th>Password</th>
+                                <td>
+                                    {% if canary_password %}
+                                        <span id="canary_password" class="canary_credentials_value" style="display: none; margin: 0;">{{canary_password}}</span>
+                                        <span id="copy_canary_password" class="ui-icon ui-icon-copy" style="cursor: pointer; display: none;" title="Copy Password"></span>
+                                        <a id="show_canary_password" class="ui-button ui-widget ui-corner-all mynode_button_small" style="width: 100px;">show password</a>
+                                    {% else %}
+                                        <span class="canary_credentials_missing">Not generated yet</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+
+                    {% if app.app_page_content is defined and app.app_page_content|length > 0 %}
+                        {% for section in app.app_page_content %}
+                            <div class="app_page_block_contents_heading">
+                                <div class="info-page-block">{{section.heading}}</div>
+                            </div>
+                            <div class="app_page_block_contents_text">
+                                {% for parapraph in section.content %}
+                                    <p>{{parapraph}}</p>
+                                {% endfor %}
+                            </div>
+                        {% endfor %}
+                    {% endif %}
+
+                </div>
+
+            </div>
+        </div>
+
+        <div id="confirm-dialog"></div>
+
+        <div id="loading_spinner_overlay" class="loading_spinner_overlay" style="display:none;">
+            <img id="loading_spinner" class="loading_image" src="{{ url_for('static', filename="images/loading.gif")}}"/>
+            <br/>
+            <span id="loading_spinner_message">Loading...</span>
+        </div>
+
+        {% include 'includes/footer.html' %}
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- update the Canary MyNode package for the v1.5.0 self-hosted flow and local image tag behavior
- generate/persist Canary self-hosted credentials and show them on the Canary app page
- expose MyNode local transaction explorers to Canary when available:
  - Mempool via CANARY_MEMPOOL_PORT=4080
  - BTC RPC Explorer via CANARY_BTC_RPC_EXPLORER_PORT=3002
  - label local explorer rows with CANARY_TX_EXPLORER_PLATFORM=mynode

## Canary tracking
- Supports schjonhaug/canary#382 for MyNode local block explorer integration.
- Also includes the batched Canary packaging updates being prepared for the next Canary release.

## Validation
- bash -n rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
- isolated mocked service-state test for pre_canary.sh:
  - no explorer services -> no local explorer env vars
  - mempool enabled -> CANARY_MEMPOOL_PORT=4080 + CANARY_TX_EXPLORER_PLATFORM=mynode
  - btcrpcexplorer enabled -> CANARY_BTC_RPC_EXPLORER_PORT=3002 + CANARY_TX_EXPLORER_PLATFORM=mynode
  - both enabled -> both explorer ports + CANARY_TX_EXPLORER_PLATFORM=mynode
- Canary backend: cargo test tx_explorer
- Canary frontend: pnpm test -- tx-explorers.test.ts tx-explorer-settings.test.tsx

## Notes
- Draft because this has not yet been validated on an actual MyNode device.
- No MyNode Bitfeed service was found, so this wires the local explorers MyNode appears to expose: Mempool and BTC RPC Explorer.