### PR TITLE
Update Canary to v1.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,3 @@ plans/
 # Release tarballs stuff
 releases/
 release.sh
-
-# myNode app build artifacts
-rootfs/standard/usr/share/mynode_apps/*/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ plans/
 releases/
 release.sh
 
+# myNode app build artifacts
+rootfs/standard/usr/share/mynode_apps/*/dist/

--- a/rootfs/standard/usr/share/mynode_apps/canary/canary.json
+++ b/rootfs/standard/usr/share/mynode_apps/canary/canary.json
@@ -16,7 +16,7 @@
         "Get instant notifications when your bitcoins move via ntfy push notifications.",
         "Features include: transaction monitoring, RBF/CPFP detection, balance alerts, and deep wallet scanning."
     ],
-    "latest_version": "v1.5.0",
+    "latest_version": "v1.5.1",
     "supported_archs": ["amd64", "arm64"],
     "download_skip": true,
     "requires_docker_image_installation": true,

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
@@ -9,7 +9,7 @@ set -e
 
 echo "==================== INSTALLING APP ===================="
 
-VERSION="${VERSION:-v1.5.0}"
+VERSION="${VERSION:-v1.5.1}"
 
 mkdir -p /opt/mynode/canary || true
 mkdir -p /mnt/hdd/mynode/canary || true

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
@@ -11,6 +11,16 @@ echo "==================== INSTALLING APP ===================="
 
 VERSION="${VERSION:-v1.5.1}"
 
+remove_canary_images_by_name() {
+    local name="$1"
+    local images
+
+    images="$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "$name" || true)"
+    [ -z "$images" ] && return 0
+
+    printf '%s\n' "$images" | xargs --no-run-if-empty docker rmi
+}
+
 mkdir -p /opt/mynode/canary || true
 mkdir -p /mnt/hdd/mynode/canary || true
 
@@ -18,8 +28,8 @@ cp -f app_data/docker-compose.yml docker-compose.yml
 
 /usr/local/bin/docker-compose down --remove-orphans 2>/dev/null || true
 
-remove_docker_images_by_name "canary-backend"
-remove_docker_images_by_name "canary-frontend"
+remove_canary_images_by_name "canary-backend"
+remove_canary_images_by_name "canary-frontend"
 
 docker pull schjonhaug/canary-backend:$VERSION
 docker pull schjonhaug/canary-frontend:$VERSION

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/install_canary.sh
@@ -11,16 +11,6 @@ echo "==================== INSTALLING APP ===================="
 
 VERSION="${VERSION:-v1.5.1}"
 
-remove_canary_images_by_name() {
-    local name="$1"
-    local images
-
-    images="$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "$name" || true)"
-    [ -z "$images" ] && return 0
-
-    printf '%s\n' "$images" | xargs --no-run-if-empty docker rmi
-}
-
 mkdir -p /opt/mynode/canary || true
 mkdir -p /mnt/hdd/mynode/canary || true
 
@@ -28,8 +18,8 @@ cp -f app_data/docker-compose.yml docker-compose.yml
 
 /usr/local/bin/docker-compose down --remove-orphans 2>/dev/null || true
 
-remove_canary_images_by_name "canary-backend"
-remove_canary_images_by_name "canary-frontend"
+remove_docker_images_by_name "canary-backend"
+remove_docker_images_by_name "canary-frontend"
 
 docker pull schjonhaug/canary-backend:$VERSION
 docker pull schjonhaug/canary-frontend:$VERSION

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
@@ -12,6 +12,11 @@ generate_secret() {
     tr -dc A-Za-z0-9 < /dev/urandom | head -c "$length"
 }
 
+service_is_enabled() {
+    local service_name="$1"
+    systemctl is-enabled "$service_name" > /dev/null 2>&1
+}
+
 cp -f app_data/docker-compose.yml docker-compose.yml
 
 # Ensure data directory exists before starting.
@@ -29,6 +34,14 @@ cat > "$ENV_FILE" <<EOF
 CANARY_SELF_HOSTED_ADMIN_PASSWORD=$(cat "$ADMIN_PASSWORD_FILE")
 JWT_SECRET=$(cat "$JWT_SECRET_FILE")
 EOF
+
+if service_is_enabled mempool; then
+    echo "CANARY_MEMPOOL_PORT=4080" >> "$ENV_FILE"
+fi
+
+if service_is_enabled btcrpcexplorer; then
+    echo "CANARY_BTC_RPC_EXPLORER_PORT=3002" >> "$ENV_FILE"
+fi
 
 chown -R bitcoin:bitcoin "$DATA_DIR"
 chmod 600 "$ADMIN_PASSWORD_FILE" "$JWT_SECRET_FILE" "$ENV_FILE"

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
@@ -43,5 +43,9 @@ if service_is_enabled btcrpcexplorer; then
     echo "CANARY_BTC_RPC_EXPLORER_PORT=3002" >> "$ENV_FILE"
 fi
 
+if service_is_enabled mempool || service_is_enabled btcrpcexplorer; then
+    echo "CANARY_TX_EXPLORER_PLATFORM=mynode" >> "$ENV_FILE"
+fi
+
 chown -R bitcoin:bitcoin "$DATA_DIR"
 chmod 600 "$ADMIN_PASSWORD_FILE" "$JWT_SECRET_FILE" "$ENV_FILE"

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/pre_canary.sh
@@ -17,6 +17,16 @@ service_is_enabled() {
     systemctl is-enabled "$service_name" > /dev/null 2>&1
 }
 
+service_is_active() {
+    local service_name="$1"
+    systemctl is-active "$service_name" > /dev/null 2>&1
+}
+
+service_is_available() {
+    local service_name="$1"
+    service_is_enabled "$service_name" && service_is_active "$service_name"
+}
+
 cp -f app_data/docker-compose.yml docker-compose.yml
 
 # Ensure data directory exists before starting.
@@ -35,15 +45,19 @@ CANARY_SELF_HOSTED_ADMIN_PASSWORD=$(cat "$ADMIN_PASSWORD_FILE")
 JWT_SECRET=$(cat "$JWT_SECRET_FILE")
 EOF
 
-if service_is_enabled mempool; then
+has_local_tx_explorer=0
+
+if service_is_available mempool; then
     echo "CANARY_MEMPOOL_PORT=4080" >> "$ENV_FILE"
+    has_local_tx_explorer=1
 fi
 
-if service_is_enabled btcrpcexplorer; then
+if service_is_available btcrpcexplorer; then
     echo "CANARY_BTC_RPC_EXPLORER_PORT=3002" >> "$ENV_FILE"
+    has_local_tx_explorer=1
 fi
 
-if service_is_enabled mempool || service_is_enabled btcrpcexplorer; then
+if [ "$has_local_tx_explorer" = "1" ]; then
     echo "CANARY_TX_EXPLORER_PLATFORM=mynode" >> "$ENV_FILE"
 fi
 

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/uninstall_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/uninstall_canary.sh
@@ -8,13 +8,23 @@ set -x
 
 echo "==================== UNINSTALLING APP ===================="
 
+remove_canary_images_by_name() {
+    local name="$1"
+    local images
+
+    images="$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "$name" || true)"
+    [ -z "$images" ] && return 0
+
+    printf '%s\n' "$images" | xargs --no-run-if-empty docker rmi
+}
+
 cp -f app_data/docker-compose.yml docker-compose.yml 2>/dev/null || true
 /usr/local/bin/docker-compose down --remove-orphans 2>/dev/null || true
 
-remove_docker_images_by_name "canary-backend"
-remove_docker_images_by_name "canary-frontend"
-remove_docker_images_by_name "schjonhaug/canary-backend"
-remove_docker_images_by_name "schjonhaug/canary-frontend"
+remove_canary_images_by_name "canary-backend"
+remove_canary_images_by_name "canary-frontend"
+remove_canary_images_by_name "schjonhaug/canary-backend"
+remove_canary_images_by_name "schjonhaug/canary-frontend"
 
 rm -rf /mnt/hdd/mynode/canary
 

--- a/rootfs/standard/usr/share/mynode_apps/canary/scripts/uninstall_canary.sh
+++ b/rootfs/standard/usr/share/mynode_apps/canary/scripts/uninstall_canary.sh
@@ -8,23 +8,13 @@ set -x
 
 echo "==================== UNINSTALLING APP ===================="
 
-remove_canary_images_by_name() {
-    local name="$1"
-    local images
-
-    images="$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "$name" || true)"
-    [ -z "$images" ] && return 0
-
-    printf '%s\n' "$images" | xargs --no-run-if-empty docker rmi
-}
-
 cp -f app_data/docker-compose.yml docker-compose.yml 2>/dev/null || true
 /usr/local/bin/docker-compose down --remove-orphans 2>/dev/null || true
 
-remove_canary_images_by_name "canary-backend"
-remove_canary_images_by_name "canary-frontend"
-remove_canary_images_by_name "schjonhaug/canary-backend"
-remove_canary_images_by_name "schjonhaug/canary-frontend"
+remove_docker_images_by_name "canary-backend"
+remove_docker_images_by_name "canary-frontend"
+remove_docker_images_by_name "schjonhaug/canary-backend"
+remove_docker_images_by_name "schjonhaug/canary-frontend"
 
 rm -rf /mnt/hdd/mynode/canary
 

--- a/rootfs/standard/usr/share/mynode_apps/canary/www/python/canary.py
+++ b/rootfs/standard/usr/share/mynode_apps/canary/www/python/canary.py
@@ -31,7 +31,6 @@ def canary_page():
         "app_status": app_status,
         "app_status_color": app_status_color,
         "app": app,
-        "canary_username": "admin@local",
         "canary_password": get_canary_password(),
     }
     return render_template("/app/canary/canary.html", **template_data)

--- a/rootfs/standard/usr/share/mynode_apps/canary/www/templates/canary.html
+++ b/rootfs/standard/usr/share/mynode_apps/canary/www/templates/canary.html
@@ -161,10 +161,6 @@
                     <div class="app_page_block_contents_text">
                         <table class="info_table" style="font-size: 12px; margin-left: 10px">
                             <tr>
-                                <th>Username</th>
-                                <td><span class="canary_credentials_value">{{canary_username}}</span></td>
-                            </tr>
-                            <tr>
                                 <th>Password</th>
                                 <td>
                                     {% if canary_password %}


### PR DESCRIPTION
## Summary
Update Canary myNode app package to v1.5.1.

## Release summary
Canary v1.5.1 improves self-hosted explorer settings and local platform labels for myNode. It also fixes address-watch syncing edge cases and small self-hosted UI/build issues.

## Upstream release
https://github.com/schjonhaug/canary/releases/tag/v1.5.1

## Test plan
- [x] Built with `mynode-sdk build canary`
- [x] Tested on local myNode
