### PR TITLE
Restore v29 OP_RETURN relay limit by default (datacarriersize=83)

### DIFF
--- a/rootfs/standard/usr/share/mynode/bitcoin.conf
+++ b/rootfs/standard/usr/share/mynode/bitcoin.conf
@@ -55,25 +55,6 @@ zmqpubrawtx=tcp://0.0.0.0:28333
 zmqpubhashblock=tcp://0.0.0.0:28334
 
 # Data carrier (OP_RETURN) relay policy
-#
-# Bitcoin Core v30 raised the default -datacarriersize from 83 to 100,000 bytes
-# (effectively uncapped) and began relaying transactions with multiple OP_RETURN
-# outputs. Setting 83 restores the limit enforced by v29 and earlier.
-#
-# 83 = 1 byte OP_RETURN + 2 bytes pushdata + 80 bytes of payload.
-#
-# This is not a perfect match for v29 behavior. On v30+ the limit applies to the
-# aggregate size of all OP_RETURN outputs in a transaction, so several small
-# OP_RETURN outputs totaling <= 83 bytes still relay, where v29 rejected any
-# transaction with more than one. Core has no option to restore the count limit.
-#
-# This is relay/mempool policy only, not consensus. Blocks containing larger
-# OP_RETURN outputs are still validated and accepted normally.
-#
-# On v29 and earlier (and on Knots) 83 is already the default, so this is a
-# no-op there. To opt out and use the v30+ default, put datacarriersize=100000
-# in the "Pre" custom config - within a bitcoin.conf the FIRST occurrence of a
-# setting wins, so a value in the "Post" custom config would have no effect.
 datacarrier=1
 datacarriersize=83
 

--- a/rootfs/standard/usr/share/mynode/bitcoin.conf
+++ b/rootfs/standard/usr/share/mynode/bitcoin.conf
@@ -54,6 +54,29 @@ zmqpubrawblock=tcp://0.0.0.0:28332
 zmqpubrawtx=tcp://0.0.0.0:28333
 zmqpubhashblock=tcp://0.0.0.0:28334
 
+# Data carrier (OP_RETURN) relay policy
+#
+# Bitcoin Core v30 raised the default -datacarriersize from 83 to 100,000 bytes
+# (effectively uncapped) and began relaying transactions with multiple OP_RETURN
+# outputs. Setting 83 restores the limit enforced by v29 and earlier.
+#
+# 83 = 1 byte OP_RETURN + 2 bytes pushdata + 80 bytes of payload.
+#
+# This is not a perfect match for v29 behavior. On v30+ the limit applies to the
+# aggregate size of all OP_RETURN outputs in a transaction, so several small
+# OP_RETURN outputs totaling <= 83 bytes still relay, where v29 rejected any
+# transaction with more than one. Core has no option to restore the count limit.
+#
+# This is relay/mempool policy only, not consensus. Blocks containing larger
+# OP_RETURN outputs are still validated and accepted normally.
+#
+# On v29 and earlier (and on Knots) 83 is already the default, so this is a
+# no-op there. To opt out and use the v30+ default, put datacarriersize=100000
+# in the "Pre" custom config - within a bitcoin.conf the FIRST occurrence of a
+# setting wins, so a value in the "Post" custom config would have no effect.
+datacarrier=1
+datacarriersize=83
+
 # MyNode Optimizations
 dbcache=500
 maxorphantx=10


### PR DESCRIPTION
## Description

Bitcoin Core v30 changed the data carrier relay policy in two ways:

- `-datacarriersize` default raised from **83** to **100,000** bytes (`MAX_STANDARD_TX_WEIGHT / WITNESS_SCALE_FACTOR`), which effectively uncaps it since the max transaction size is hit first.
- Transactions with **multiple** OP_RETURN outputs are now relayed and mined, where v29 rejected them as `multi-op-return`. The size limit is now measured as the aggregate of all OP_RETURN scriptPubKeys rather than per output.

This adds `datacarrier=1` / `datacarriersize=83` to the generated `bitcoin.conf` so nodes keep the relay policy they have today when they are eventually upgraded to v30+. From the [v30.0 release notes](https://bitcoincore.org/en/releases/30.0/): *"It can be overridden with `-datacarriersize=83` to revert to the limit enforced in previous versions."*

**This is a no-op right now.** `BTC_VERSION` is `29.3`, where 83 is already the default; Knots `29.x` also defines `MAX_OP_RETURN_RELAY = 83`. The setting only starts doing work on a future v30+ bump, so this is purely a forward-compatibility change with no behavior change for existing users.

### Caveats

- **Not an exact v29 match.** With `datacarriersize=83` on v30+, a transaction with several small OP_RETURN outputs totaling ≤ 83 bytes still relays, where v29 rejected any transaction with more than one. Core has no option to restore the count limit — `-datacarriercount` is only a draft proposal ([#33595](https://github.com/bitcoin/bitcoin/issues/33595)), and it appears nowhere in `init.cpp` or `policy/policy.cpp` on master as of 31.1.
- **Relay/mempool policy only, not consensus.** Blocks containing larger OP_RETURN outputs are still fully validated and accepted. No fork risk in either direction.
- **Opting out requires the "Pre" custom config, not "Post".** Within a `bitcoin.conf` the *first* occurrence of a setting wins (Core's `GetSetting` applies `reverse_precedence` for config-file sources), and `mynode_gen_bitcoin_config.sh` appends pre-config before the mynode defaults and post-config after. A user wanting the v30+ default needs `datacarriersize=100000` in the Pre config; putting it in Post would silently do nothing.

Config-file settings are also forgiving of version skew in general — bitcoind reads with `ignore_invalid_keys=true` and just logs `Ignoring unknown configuration value X`, which is why the existing `mempoolfullrbf=1` line is harmless on 29.x even though that option was removed in 29.0.

## Checklist

* [ ] tested successfully on local MyNode, if yes, list the device(s) below
* [x] mentioned related open issue, if any — none

## List of test device(s)

Not tested on hardware. The change is two lines in `rootfs/standard/usr/share/mynode/bitcoin.conf`, which `mynode_gen_bitcoin_config.sh` concatenates verbatim into the generated config; worth a boot check that `bitcoin.conf` regenerates and bitcoind starts clean.